### PR TITLE
ci(db): run migrations again after rolling them back

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           DB_HOST: postgres
 
-      - name: Rollback AdonisJS migrations
-        run: node ace migration:reset
+      - name: Rollback and rerun AdonisJS migrations
+        run: node ace migration:refresh
         env:
           DB_HOST: postgres


### PR DESCRIPTION
- Running the migration for the first time verifies that the migration up() functions work on a fresh database.
- Rolling back the migration verifies that the down() functions work.
- Running the migration again after a rollback verifies that the down() functions deleted all created tables and types, as Lucid ORM does not use `IF NOT EXIST` clauses in the generated SQL queries and will error out if a table or type did not get cleaned up.

After this PR, the only edge cases that CI will not catch are column and type modifications that are not reverted properly. Verifying those would likely require more effort than simply running a migration forward and back a few times.