### PR TITLE
fix(models): rename typedModel's meta field

### DIFF
--- a/app/decorators/typed_model.ts
+++ b/app/decorators/typed_model.ts
@@ -10,7 +10,7 @@ export type TypedModelOptions = Record<string, ColumnType>;
 
 export interface ColumnDef extends ColumnOptions {
   meta?: {
-    type?: ColumnType;
+    declaredType?: ColumnType;
   };
 }
 
@@ -74,7 +74,7 @@ export function typedModel<T extends LucidModel>(options: TypedModelOptions) {
         continue;
       }
       columnDef.meta = columnDef.meta ?? {};
-      columnDef.meta.type = columnType;
+      columnDef.meta.declaredType = columnType;
     }
     return constructor;
   };

--- a/app/scopes/search_helper.ts
+++ b/app/scopes/search_helper.ts
@@ -25,7 +25,7 @@ const types = new Set(["number", "string", "boolean", "DateTime"]);
 
 export interface ColumnDefExplicit extends ModelColumnOptions {
   meta: {
-    type: ColumnType;
+    declaredType: ColumnType;
   };
 }
 
@@ -119,7 +119,7 @@ function handleArray(
   column: ColumnDefExplicit,
   values: string[],
 ) {
-  const columnType = column.meta.type;
+  const columnType = column.meta.declaredType;
   const invalid = arrayTypeCheckHelper(values, columnType);
   if (invalid.length > 0) {
     throw new BadRequestException(
@@ -141,7 +141,7 @@ function handleFromTo(
   column: ColumnDefExplicit,
   value: FromTo,
 ) {
-  const columnType = column.meta.type;
+  const columnType = column.meta.declaredType;
   if (columnType !== "number" && columnType !== "DateTime") {
     // [from]/[to] make sense only on number or date
     throw new BadRequestException(
@@ -197,7 +197,7 @@ function handleDirectValue(
   value: string,
 ) {
   // const columnType = extractType(column);
-  const columnType = column.meta.type;
+  const columnType = column.meta.declaredType;
   const invalid = arrayTypeCheckHelper([value], columnType);
   if (invalid.length > 0) {
     throw new BadRequestException(
@@ -267,11 +267,10 @@ function extractEntry<T extends LucidModel>(
   }
   // predicate for ts type safety
   const isTypeValid = (column: ColumnDef): column is ColumnDefExplicit => {
-    return column.meta !== undefined
-      ? column.meta.type !== undefined
-        ? types.has(column.meta.type)
-        : false
-      : false;
+    return (
+      column.meta?.declaredType !== undefined &&
+      types.has(column.meta.declaredType)
+    );
   };
   const column = model.$getColumn(param);
   if (column === undefined) {
@@ -286,7 +285,7 @@ function extractEntry<T extends LucidModel>(
   if (["development", "testing"].includes(app)) {
     logger.warn(
       `\nColumn type for '${column.columnName}' not defined or not supported. \n` +
-        `Check 'meta: type' property in columnDefinitions. \n` +
+        `Check 'meta: declaredType' property in columnDefinitions. \n` +
         `Supported types are ["string", "number", "boolean", "DateTime"]. \n` +
         `Exclude explicitly unsupported types in the scope invoking level.`,
     );


### PR DESCRIPTION
The previous name ('type') was conflicting with lucid's internal field, which caused datetimes to not function on models decorated with the typedModel decorator.
I've renamed the field to 'declaredType' to avoid such conflicts as the issues arising from them are rather hard to debug and track down.

Discord discussion on this topic: https://discord.com/channels/687360174377533442/1325560731331985408