### PR TITLE
fix: actually implement searching by enum values

### DIFF
--- a/app/decorators/typed_model.ts
+++ b/app/decorators/typed_model.ts
@@ -4,13 +4,16 @@ import {
   ModelColumnOptions,
 } from "@adonisjs/lucid/types/model";
 
-export type ColumnType = "string" | "number" | "boolean" | "DateTime";
+type SharedColumnTypes = "string" | "number" | "boolean" | "DateTime";
+export type ColumnType = SharedColumnTypes | "enum";
+type InputColumnTypes = SharedColumnTypes | Record<string, string>; // Record<string, string> represents a runtime enum
 
-export type TypedModelOptions = Record<string, ColumnType>;
+export type TypedModelOptions = Record<string, InputColumnTypes>;
 
 export interface ColumnDef extends ColumnOptions {
   meta?: {
     declaredType?: ColumnType;
+    allowedValues?: string[];
   };
 }
 
@@ -74,7 +77,13 @@ export function typedModel<T extends LucidModel>(options: TypedModelOptions) {
         continue;
       }
       columnDef.meta = columnDef.meta ?? {};
-      columnDef.meta.declaredType = columnType;
+      if (typeof columnType === "string") {
+        columnDef.meta.declaredType = columnType;
+      } else {
+        // enums
+        columnDef.meta.declaredType = "enum";
+        columnDef.meta.allowedValues = Object.values(columnType);
+      }
     }
     return constructor;
   };

--- a/app/models/change.ts
+++ b/app/models/change.ts
@@ -16,7 +16,7 @@ import Version from "./version.js";
   id: "number",
   versionId: "number",
   name: "string",
-  type: "string",
+  type: ChangeType,
   description: "string",
   createdAt: "DateTime",
   updatedAt: "DateTime",


### PR DESCRIPTION
fixes #82 

please let me know if I've unknowingly (or knowingly) committed something that could be considered a programming war crime

but um, yeah, i've actually implemented proper enum support for typed models and search scopes
to use, simply pass in the enum type to the `@typedModel` decorator
under the hood, it will assign the column an "enum" type and embed allowed enum values in a new meta prop