### PR TITLE
feat(fileService): add more methods for uploading files

### DIFF
--- a/app/controllers/files_controller.ts
+++ b/app/controllers/files_controller.ts
@@ -11,7 +11,7 @@ export default class FilesController {
       return response.badRequest("No file provided");
     }
 
-    const key = await filesService.uploadFile(file);
+    const key = await filesService.uploadMultipartFile(file);
 
     return response.status(201).send({ key });
   }

--- a/app/services/files_service.ts
+++ b/app/services/files_service.ts
@@ -19,7 +19,14 @@ export default class FilesService {
     return `${randomUUID()}.${extname ?? "bin"}`;
   }
 
-  // Uploads a multipart file to storage (uploaded via API)
+  /**
+   * Uploads a multipart file to storage.
+   *
+   * Use this if you're handling an API request and received a `MultipartFile` from adonis
+   * @param file - The file to upload
+   * @returns Key of the newly uploaded file
+   * @throws {FileServiceFileUploadError} There was an issue uploading the file. Check the cause prop for details.
+   */
   async uploadMultipartFile(file: MultipartFile): Promise<string> {
     const key = this.generateKey(file.extname);
     try {
@@ -30,7 +37,16 @@ export default class FilesService {
     }
   }
 
-  // Uploads any readable stream, such as Response.body
+  /**
+   * Uploads any readable stream to storage.
+   *
+   * Use this if you can get a readable stream from another API, such as `fetch()`.
+   * Calling this function with a stream probably will be more efficient than reading the stream and using `uploadFromMemory()`.
+   * @param stream - Stream with file contents to upload
+   * @param extname - File's extension. Defaults to `.bin`.
+   * @returns Key of the newly uploaded file
+   * @throws {FileServiceFileUploadError} There was an issue uploading the file. Check the cause prop for details.
+   */
   async uploadStream(
     stream: Readable,
     extname: string | undefined = undefined,
@@ -44,7 +60,15 @@ export default class FilesService {
     }
   }
 
-  // Uploads a file with arbitrary contents
+  /**
+   * Uploads a file with arbitrary contents
+   *
+   * Use this function only if you cannot easily use other `upload*` functions.
+   * @param data - File contents
+   * @param extname - File's extension. Defaults to `.bin`.
+   * @returns Key of the newly uploaded file
+   * @throws {FileServiceFileUploadError} There was an issue uploading the file. Check the cause prop for details.
+   */
   async uploadFromMemory(
     data: string | Uint8Array,
     extname: string | undefined = undefined,
@@ -58,9 +82,14 @@ export default class FilesService {
     }
   }
 
-  // Uploads a file from the local filesystem
-  // Pass removeSourceFile = true to remove the original file
-  // If the path is not absolute, it will be resolved as a path relative to PWD (which should be the project root)
+  /**
+   * Uploads a file from the local filesystem
+   *
+   * @param path - Path to file. Relative paths are resolved relative to `$PWD` (usually the project root)
+   * @param removeSourceFile - Whether the file should be removed after upload.
+   * @returns Key of the newly uploaded file
+   * @throws {FileServiceFileUploadError} There was an issue uploading the file. Check the cause prop for details.
+   */
   async uploadLocalFile(
     path: string,
     removeSourceFile = false,
@@ -79,6 +108,13 @@ export default class FilesService {
     }
   }
 
+  /**
+   * Constructs a full file URL from its key
+   *
+   * @param key - File's key
+   * @returns The full URL to the file
+   * @throws {FileServiceFileReadError} There was an issue constructing the URL. Check the cause prop for details.
+   */
   async getFileUrl(key: string): Promise<string> {
     // Get file URL from storage
     try {
@@ -88,6 +124,12 @@ export default class FilesService {
     }
   }
 
+  /**
+   * Deletes a file from storage
+   *
+   * @param key - File's key
+   * @throws {FileServiceFileDeleteError} There was an issue deleting the file. Check the cause prop for details.
+   */
   async deleteFile(key: string): Promise<void> {
     // Delete file from storage
     try {

--- a/app/services/files_service.ts
+++ b/app/services/files_service.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import nodePath from "node:path";
+import { Readable } from "node:stream";
 
 import { MultipartFile } from "@adonisjs/core/types/bodyparser";
 import drive from "@adonisjs/drive/services/main";
@@ -10,11 +12,67 @@ import {
 } from "#exceptions/file_service_errors";
 
 export default class FilesService {
-  async uploadFile(file: MultipartFile): Promise<string> {
-    // Upload file to storage
-    const key = `${randomUUID()}.${file.extname}`;
+  private generateKey(extname: string | undefined): string {
+    if (extname?.length === 0) {
+      extname = undefined;
+    }
+    return `${randomUUID()}.${extname ?? "bin"}`;
+  }
+
+  // Uploads a multipart file to storage (uploaded via API)
+  async uploadMultipartFile(file: MultipartFile): Promise<string> {
+    const key = this.generateKey(file.extname);
     try {
       await file.moveToDisk(key);
+      return key;
+    } catch (error) {
+      throw new FileServiceFileUploadError(error as Error);
+    }
+  }
+
+  // Uploads any readable stream, such as Response.body
+  async uploadStream(
+    stream: Readable,
+    extname: string | undefined = undefined,
+  ): Promise<string> {
+    const key = this.generateKey(extname);
+    try {
+      await drive.use().putStream(key, stream);
+      return key;
+    } catch (error) {
+      throw new FileServiceFileUploadError(error as Error);
+    }
+  }
+
+  // Uploads a file with arbitrary contents
+  async uploadFromMemory(
+    data: string | Uint8Array,
+    extname: string | undefined = undefined,
+  ): Promise<string> {
+    const key = this.generateKey(extname);
+    try {
+      await drive.use().put(key, data);
+      return key;
+    } catch (error) {
+      throw new FileServiceFileUploadError(error as Error);
+    }
+  }
+
+  // Uploads a file from the local filesystem
+  // Pass removeSourceFile = true to remove the original file
+  // If the path is not absolute, it will be resolved as a path relative to PWD (which should be the project root)
+  async uploadLocalFile(
+    path: string,
+    removeSourceFile = false,
+  ): Promise<string> {
+    path = nodePath.resolve(path);
+    const key = this.generateKey(nodePath.extname(path).substring(1));
+    try {
+      if (removeSourceFile) {
+        await drive.use().moveFromFs(path, key);
+      } else {
+        await drive.use().copyFromFs(path, key);
+      }
       return key;
     } catch (error) {
       throw new FileServiceFileUploadError(error as Error);
@@ -29,6 +87,7 @@ export default class FilesService {
       throw new FileServiceFileReadError(error as Error);
     }
   }
+
   async deleteFile(key: string): Promise<void> {
     // Delete file from storage
     try {

--- a/database/seeders/about_us_seeder.ts
+++ b/database/seeders/about_us_seeder.ts
@@ -1,7 +1,3 @@
-import * as fs from "node:fs";
-import path from "node:path";
-
-import { MultipartFile } from "@adonisjs/core/types/bodyparser";
 import { BaseSeeder } from "@adonisjs/lucid/seeders";
 
 import { LinkType } from "#enums/link_type";
@@ -26,35 +22,8 @@ export default class extends BaseSeeder {
       <p>Jeżeli to, co robimy, do Ciebie przemawia, zapraszamy w nasze szeregi! Informacje o trwających rekrutacjach znajdziesz na naszych mediach społecznościowych poniżej.</p>`;
 
     const filesService = new FilesService();
-
-    const filePath = path.resolve(
-      import.meta.dirname,
-      "..",
-      "..",
-      "assets",
-      "topwr_cover.png",
-    );
-    const fileStats = fs.statSync(filePath);
-
-    const file = {
-      size: fileStats.size,
-      extname: "png",
-      tmpPath: filePath,
-      moveToDisk: async (key: string) => {
-        const destination = path.resolve(
-          import.meta.dirname,
-          "..",
-          "..",
-          "storage",
-          key,
-        );
-
-        fs.copyFileSync(filePath, destination);
-      },
-    };
-
-    const result = await filesService.uploadMultipartFile(
-      file as MultipartFile,
+    const result = await filesService.uploadLocalFile(
+      "./assets/topwr_cover.png",
     );
 
     const coverPhotoKey = result;

--- a/database/seeders/about_us_seeder.ts
+++ b/database/seeders/about_us_seeder.ts
@@ -53,7 +53,9 @@ export default class extends BaseSeeder {
       },
     };
 
-    const result = await filesService.uploadFile(file as MultipartFile);
+    const result = await filesService.uploadMultipartFile(
+      file as MultipartFile,
+    );
 
     const coverPhotoKey = result;
 


### PR DESCRIPTION
This PR adds methods such as `uploadStream` and `uploadFromMemory`, which aim to replace the existing hacks of impersonating the `MultipartFile` interface to upload custom files.

Now, you can simply call one of these functions with an appropriate input type, which should be easier to construct than `MultipartFile`.