### PR TITLE
fix(scraper): console.error() module errors instead of using cliui

### DIFF
--- a/commands/db_scrape.ts
+++ b/commands/db_scrape.ts
@@ -111,8 +111,14 @@ export default class DbScrape extends BaseCommand {
     const tasks = this.ui.tasks({ verbose: true });
 
     for (const { Module, instance } of selectedModules) {
+      // @ts-expect-error https://github.com/poppinss/cliui/issues/22
       tasks.add(Module.taskTitle ?? Module.description, async (task) => {
-        return ((await instance.run(task)) as string | undefined) ?? "Done";
+        try {
+          return ((await instance.run(task)) as string | undefined) ?? "Done";
+        } catch (e) {
+          console.error(e);
+          return task.error("Module threw an error");
+        }
       });
     }
 


### PR DESCRIPTION
cliui doesn't print error causes, which produces worse errors
so let's just console.error() the error out instead

before
![image](https://github.com/user-attachments/assets/e8cfb0dc-fd01-470b-8ff6-a4558a2db9a5)

after
![image](https://github.com/user-attachments/assets/8eb1f513-3b29-4fcf-b82f-4e470ad326a9)
