### PR TITLE
feat: organizations scripts

### DIFF
--- a/app/models/student_organization.ts
+++ b/app/models/student_organization.ts
@@ -45,7 +45,7 @@ export default class StudentOrganization extends BaseModel {
   declare name: string;
 
   @column()
-  declare departmentId: number;
+  declare departmentId: number | null;
 
   @column()
   declare logo: string | null;

--- a/database/migrations/1733672331665_create_student_organizations_table.ts
+++ b/database/migrations/1733672331665_create_student_organizations_table.ts
@@ -14,7 +14,7 @@ export default class extends BaseSchema {
     this.schema.createTable(this.tableName, (table) => {
       table.increments("id");
       table.text("name").notNullable();
-      table.integer("department_id").unsigned().notNullable();
+      table.integer("department_id").unsigned().nullable();
       table.text("logo").nullable();
       table.text("cover").nullable();
       table.text("description").nullable();

--- a/database/scrapers/organizations.ts
+++ b/database/scrapers/organizations.ts
@@ -1,0 +1,235 @@
+import { Readable } from "node:stream";
+
+import { BaseScraperModule } from "#commands/db_scrape";
+import { LinkType } from "#enums/link_type";
+import { OrganizationSource } from "#enums/organization_source";
+import { OrganizationType } from "#enums/organization_type";
+import StudentOrganization from "#models/student_organization";
+import StudentOrganizationLink from "#models/student_organization_link";
+import StudentOrganizationTag from "#models/student_organization_tag";
+import FilesService from "#services/files_service";
+
+interface DirectusResponse<T> {
+  data: T[];
+}
+
+interface DirectusTag {
+  id: number;
+  name: string;
+}
+
+interface DirectusLink {
+  id: number;
+  name: string;
+  link: string;
+  scientific_circle_id: number;
+}
+
+interface DirectusOrganization {
+  id: number;
+  date_created: string;
+  date_updated: string;
+  name: string;
+  logo: string;
+  cover: string;
+  description: string;
+  type: string;
+  source: string;
+  shortDescription: string;
+  department: number;
+  useCoverAsPreviewPhoto: boolean;
+  isStrategic: boolean;
+  tags: number[];
+  links: number[];
+}
+
+interface FileMetaResponse {
+  data: { filename_disk: string };
+}
+export default class OrganizationsScraper extends BaseScraperModule {
+  static name = "Organizations";
+  static description =
+    "populates all required tables for organizations (tags, links,...)";
+  static taskTitle = "Scraping organizations";
+  private filesService = new FilesService();
+  private readonly urls = {
+    orgs: "https://admin.topwr.solvro.pl/items/Scientific_Circles",
+    tags: "https://admin.topwr.solvro.pl/items/Tags",
+    pivot_tags: "https://admin.topwr.solvro.pl/items/Scientific_Circles_Tags",
+    links: "https://admin.topwr.solvro.pl/items/Scientific_Circles_Links",
+  };
+  private readonly linkDomains: [string, LinkType][] = [
+    ["facebook.com", LinkType.Facebook],
+    ["instagram.com", LinkType.Instagram],
+    ["linkedin.com", LinkType.LinkedIn],
+    ["youtube.com", LinkType.YouTube],
+    ["github.com", LinkType.GitHub],
+    ["x.com", LinkType.X],
+    ["twitter.com", LinkType.X],
+    ["discord.com", LinkType.Discord],
+    ["discord.gg", LinkType.Discord],
+    ["tiktok.com", LinkType.TikTok],
+    ["twitch.tv", LinkType.Twitch],
+  ];
+
+  public async run() {
+    const [orgs, tags, links] = (await Promise.all([
+      this.fetchJSON(this.urls.orgs, "organizations"),
+      this.fetchJSON(this.urls.tags, "tags"),
+      this.fetchJSON(this.urls.links, "links"),
+    ])) as [
+      DirectusResponse<DirectusOrganization>,
+      DirectusResponse<DirectusTag>,
+      DirectusResponse<DirectusLink>,
+    ];
+    const tagsModels = new Map(
+      tags.data.map((tag) => [
+        tag.id,
+        { tag: tag.name } as StudentOrganizationTag,
+      ]),
+    );
+    await StudentOrganizationTag.createMany([
+      ...tagsModels.values().toArray(),
+      { tag: "strategic" },
+    ]);
+    const linksModels = links.data.map((link) => {
+      return {
+        id: link.id,
+        link: link.link,
+        type: this.detectLinkType(link.link),
+        studentOrganizationId: link.scientific_circle_id,
+      } as StudentOrganizationLink;
+    });
+    for (const org of orgs.data) {
+      const logo =
+        org.logo !== null && org.logo !== undefined
+          ? await this.newAsset(org.logo)
+          : null;
+      const cover =
+        org.cover !== null && org.cover !== undefined
+          ? await this.newAsset(org.cover)
+          : null;
+      const orgModel = await StudentOrganization.create({
+        id: org.id,
+        name: org.name,
+        departmentId: org.department,
+        logo,
+        cover,
+        description: org.description,
+        shortDescription: org.shortDescription,
+        coverPreview: org.useCoverAsPreviewPhoto,
+        source: this.convertSource(org.source),
+        organizationType: this.convertType(org.type),
+      });
+      const a = org.tags
+        .map((tagId) => tagsModels.get(tagId)?.tag)
+        .filter((tagModel) => tagModel !== undefined);
+      if (org.isStrategic) {
+        a.push("strategic");
+      }
+      if (a.length < org.tags.length) {
+        this.logger.warning(
+          `There are some undefined tags in organization ${org.name}. Omitting these tags.`,
+        );
+      }
+      await Promise.all([
+        orgModel.related("tags").attach(a),
+        orgModel
+          .related("links")
+          .createMany(
+            linksModels.filter((link) => link.studentOrganizationId === org.id),
+          ),
+      ]);
+    }
+  }
+
+  private detectLinkType(link: string): LinkType {
+    let url;
+    try {
+      url = new URL(link);
+    } catch {
+      this.logger.warning(
+        `Failed to parse social link '${link}' - assigning the Default linktype`,
+      );
+      return LinkType.Default;
+    }
+    if (url.protocol === "mailto:") {
+      return LinkType.Mail;
+    }
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      this.logger.warning(
+        `Encountered an unknown protocol '${url.protocol}' in social link '${link}' - assigning the Default linktype`,
+      );
+      return LinkType.Default;
+    }
+    for (const [domain, type] of this.linkDomains) {
+      if (url.host === domain || url.host.endsWith(`.${domain}`)) {
+        return type;
+      }
+    }
+    this.logger.info(
+      `Social link '${link}' matched no domains - assigning the Default linktype`,
+    );
+    return LinkType.Default;
+  }
+
+  private convertSource(source: string): OrganizationSource {
+    switch (source) {
+      case "student_department":
+        return OrganizationSource.StudentDepartment;
+      case "aktywni_website":
+        return OrganizationSource.PwrActive;
+      case "manual_entry":
+        return OrganizationSource.Manual;
+    }
+    this.logger.warning(
+      `Unknown source '${source}' - assigning the Manual source`,
+    );
+    return OrganizationSource.Manual;
+  }
+
+  private convertType(type: string): OrganizationType {
+    switch (type) {
+      case "scientific_cirlce": //XDDDDDD
+        return OrganizationType.ScientificCircle;
+      case "student_organization":
+        return OrganizationType.StudentOrganization;
+      case "student_media":
+        return OrganizationType.StudentMedium;
+      case "cultural_agenda":
+        return OrganizationType.CultureAgenda;
+      case "student_council":
+        return OrganizationType.StudentCouncil;
+    }
+    this.logger.warning(
+      `Unknown type '${type}' - assigning the Student Organization type`,
+    );
+    return OrganizationType.StudentOrganization;
+  }
+  private async newAsset(directusId: string): Promise<string> {
+    const extension = (
+      (await this.fetchJSON(
+        `https://admin.topwr.solvro.pl/files/${directusId}?fields=filename_disk`,
+        directusId,
+      )) as FileMetaResponse
+    ).data.filename_disk
+      .split(".")
+      .pop();
+    if (extension === undefined) {
+      this.logger.warning(
+        `Failed to get extension for asset ${directusId} - using default 'bin'`,
+      );
+    }
+    const imageStream = await this.fetchAndCheckStatus(
+      `https://admin.topwr.solvro.pl/assets/${directusId}`,
+      `image file ${directusId}`,
+    ).then((response) => response.body);
+    if (imageStream === null) {
+      throw new Error(`Failed to get image stream for asset ${directusId}`);
+    }
+    return this.filesService.uploadStream(
+      Readable.fromWeb(imageStream),
+      extension,
+    );
+  }
+}

--- a/database/scrapers/organizations.ts
+++ b/database/scrapers/organizations.ts
@@ -141,10 +141,13 @@ export default class OrganizationsScraper extends BaseScraperModule {
       links.data
         .filter((link) => link.scientific_circle_id !== null)
         .map((link) => {
+          const url = link.link.includes(":")
+            ? link.link
+            : `https://${link.link}`;
           return {
             id: link.id,
-            link: link.link,
-            type: this.detectLinkType(link.link),
+            link: url,
+            type: this.detectLinkType(url),
             studentOrganizationId: link.scientific_circle_id,
           } as StudentOrganizationLink;
         }),

--- a/database/scrapers/organizations.ts
+++ b/database/scrapers/organizations.ts
@@ -123,18 +123,18 @@ export default class OrganizationsScraper extends BaseScraperModule {
         source: this.convertSource(org.source),
         organizationType: this.convertType(org.type),
       });
-      const a = org.tags
+      const tagNames = org.tags
         .map((tagId) => tagsModels.get(tagId)?.tag)
         .filter((tagModel) => tagModel !== undefined);
-      if (a.length < org.tags.length) {
+      if (tagNames.length < org.tags.length) {
         this.logger.warning(
           `There are some undefined tags in organization ${org.name}. Omitting these tags.`,
         );
       }
       if (org.isStrategic) {
-        a.push("strategic");
+        tagNames.push("strategic");
       }
-      await orgModel.related("tags").attach(a);
+      await orgModel.related("tags").attach(tagNames);
       const links = [];
       for (const linkId of org.links) {
         try {
@@ -220,7 +220,7 @@ export default class OrganizationsScraper extends BaseScraperModule {
     return OrganizationType.StudentOrganization;
   }
   private async newAsset(directusId: string): Promise<string> {
-    const extension = (
+    let extension = (
       (await this.fetchJSON(
         `https://admin.topwr.solvro.pl/files/${directusId}?fields=filename_disk`,
         directusId,
@@ -232,6 +232,7 @@ export default class OrganizationsScraper extends BaseScraperModule {
       this.logger.warning(
         `Failed to get extension for asset ${directusId} - using default 'bin'`,
       );
+      extension = "bin";
     }
     const imageStream = await this.fetchAndCheckStatus(
       `https://admin.topwr.solvro.pl/assets/${directusId}`,

--- a/database/scrapers/organizations.ts
+++ b/database/scrapers/organizations.ts
@@ -124,13 +124,13 @@ export default class OrganizationsScraper extends BaseScraperModule {
       const a = org.tags
         .map((tagId) => tagsModels.get(tagId)?.tag)
         .filter((tagModel) => tagModel !== undefined);
-      if (org.isStrategic) {
-        a.push("strategic");
-      }
       if (a.length < org.tags.length) {
         this.logger.warning(
           `There are some undefined tags in organization ${org.name}. Omitting these tags.`,
         );
+      }
+      if (org.isStrategic) {
+        a.push("strategic");
       }
       await Promise.all([
         orgModel.related("tags").attach(a),

--- a/database/scrapers/organizations.ts
+++ b/database/scrapers/organizations.ts
@@ -7,6 +7,7 @@ import StudentOrganization from "#models/student_organization";
 import StudentOrganizationLink from "#models/student_organization_link";
 import StudentOrganizationTag from "#models/student_organization_tag";
 import FilesService from "#services/files_service";
+import { fixSequence } from "#utils/db";
 
 interface DirectusResponse<T> {
   data: T[];
@@ -133,6 +134,8 @@ export default class OrganizationsScraper extends BaseScraperModule {
       }
       await orgModel.related("tags").attach(tagNames);
     }
+    const newOrgId = await fixSequence("student_organizations");
+    task.update(`Organizations created, next ID set to ${newOrgId}`);
     task.update("Creating links...");
     await StudentOrganizationLink.createMany(
       links.data
@@ -146,6 +149,8 @@ export default class OrganizationsScraper extends BaseScraperModule {
           } as StudentOrganizationLink;
         }),
     );
+    const newLinkId = await fixSequence("student_organization_links");
+    task.update(`Links created, next ID set to ${newLinkId}`);
   }
 
   private convertSource(source: string): OrganizationSource {

--- a/database/scrapers/organizations.ts
+++ b/database/scrapers/organizations.ts
@@ -67,19 +67,6 @@ export default class OrganizationsScraper extends BaseScraperModule {
     links:
       "https://admin.topwr.solvro.pl/items/Scientific_Circles_Links?limit=-1",
   };
-  private readonly linkDomains: [string, LinkType][] = [
-    ["facebook.com", LinkType.Facebook],
-    ["instagram.com", LinkType.Instagram],
-    ["linkedin.com", LinkType.LinkedIn],
-    ["youtube.com", LinkType.YouTube],
-    ["github.com", LinkType.GitHub],
-    ["x.com", LinkType.X],
-    ["twitter.com", LinkType.X],
-    ["discord.com", LinkType.Discord],
-    ["discord.gg", LinkType.Discord],
-    ["tiktok.com", LinkType.TikTok],
-    ["twitch.tv", LinkType.Twitch],
-  ];
 
   public async run() {
     const [orgs, tags, links, tagsPivot] = (await Promise.all([
@@ -160,36 +147,6 @@ export default class OrganizationsScraper extends BaseScraperModule {
           } as StudentOrganizationLink;
         }),
     );
-  }
-
-  private detectLinkType(link: string): LinkType {
-    let url;
-    try {
-      url = new URL(link);
-    } catch {
-      this.logger.warning(
-        `Failed to parse social link '${link}' - assigning the Default linktype`,
-      );
-      return LinkType.Default;
-    }
-    if (url.protocol === "mailto:") {
-      return LinkType.Mail;
-    }
-    if (url.protocol !== "https:" && url.protocol !== "http:") {
-      this.logger.warning(
-        `Encountered an unknown protocol '${url.protocol}' in social link '${link}' - assigning the Default linktype`,
-      );
-      return LinkType.Default;
-    }
-    for (const [domain, type] of this.linkDomains) {
-      if (url.host === domain || url.host.endsWith(`.${domain}`)) {
-        return type;
-      }
-    }
-    this.logger.info(
-      `Social link '${link}' matched no domains - assigning the Default linktype`,
-    );
-    return LinkType.Default;
   }
 
   private convertSource(source: string): OrganizationSource {

--- a/database/scrapers/organizations.ts
+++ b/database/scrapers/organizations.ts
@@ -99,7 +99,7 @@ export default class OrganizationsScraper extends BaseScraperModule {
           `organization ${id}`,
         )) as DirectusSingleResponse<DirectusOrganization>;
       } catch (e) {
-        this.logger.warning(e);
+        this.logger.warning(`${e}`);
         continue;
       }
       const org = res.data;

--- a/database/scrapers/organizations.ts
+++ b/database/scrapers/organizations.ts
@@ -1,7 +1,6 @@
 import { Readable } from "node:stream";
 
 import { BaseScraperModule } from "#commands/db_scrape";
-import { LinkType } from "#enums/link_type";
 import { OrganizationSource } from "#enums/organization_source";
 import { OrganizationType } from "#enums/organization_type";
 import StudentOrganization from "#models/student_organization";


### PR DESCRIPTION
Sorry for the little delay, but here it is.

* there is a change to directus regarding strategic status: now strategic is a tag
* also, the way I loop through the ids is pretty disgusting, but I didn't find a way to get around the pagination limit of 100 in the api response, maybe you know a better way?
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `OrganizationsScraper`, refactor link type detection, and update student organization schema to allow nullable `departmentId`.
> 
>   - **New Features**:
>     - Add `OrganizationsScraper` in `database/scrapers/organizations.ts` to populate tables for organizations, including tags and links.
>   - **Refactoring**:
>     - Move `detectLinkType` logic to `link_type.ts` and update `BaseScraperModule` in `db_scrape.ts` to use it.
>     - Remove redundant `detectLinkType` and `linkDomains` from `contributors.ts`.
>   - **Database Schema**:
>     - Update `departmentId` to be nullable in `student_organization.ts` and `1733672331665_create_student_organizations_table.ts`.
>   - **Miscellaneous**:
>     - Add `strategiczne` tag in `organizations.ts` for strategic organizations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-topwr&utm_source=github&utm_medium=referral)<sup> for c06bb8d62dc32ce8ab31c14ff1c4b7fd3ee55947. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->