### PR TITLE
fix: add sequence fixing in buildings scraper

### DIFF
--- a/database/scrapers/buildings.ts
+++ b/database/scrapers/buildings.ts
@@ -7,6 +7,7 @@ import { BuildingIcon } from "#enums/building_icon";
 import Building from "#models/building";
 import Campus from "#models/campus";
 import FilesService from "#services/files_service";
+import { fixSequence } from "#utils/db";
 
 const buildingsPath = "https://admin.topwr.solvro.pl/items/Buildings/";
 const assetsPath = "https://admin.topwr.solvro.pl/assets/";
@@ -127,6 +128,8 @@ export default class BuildingsScraper extends BaseScraperModule {
       }),
     );
     task.update("Buildings created !");
+    await fixSequence("buildings", "id");
+    task.update("Fixed Buildings id autoincrementing");
     //save changes for campuses
     await Promise.all(updatedCampuses.map((campus) => campus.save()));
     task.update("campuses cover assigned !");


### PR DESCRIPTION
I added functionality exposed in db utils - `fixSequence` for Buildings creation because they had manually inserted id's which are autoincrement in database
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `fixSequence` call in `BuildingsScraper.run()` to correct autoincrement sequence for `buildings` table.
> 
>   - **Behavior**:
>     - Adds `fixSequence` call in `BuildingsScraper.run()` in `buildings.ts` to correct autoincrement sequence for `buildings` table after manual ID insertion.
>     - Updates task status messages to reflect sequence fixing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-topwr&utm_source=github&utm_medium=referral)<sup> for 3381dc267b3965ef97efffe6f95ba6ae6441c3e2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->