### PR TITLE
feat(AdminPanel): add photo_dropbox component

### DIFF
--- a/app/admin/component_loader.ts
+++ b/app/admin/component_loader.ts
@@ -4,4 +4,8 @@ export const componentLoader = new ComponentLoader();
 
 export const Components = {
   Dashboard: componentLoader.add("Dashboard", "./components/dashboard"),
+  PhotoDropbox: componentLoader.add(
+    "PhotoDropbox",
+    "./components/photo_dropbox",
+  ),
 };

--- a/app/admin/components/photo_dropbox.tsx
+++ b/app/admin/components/photo_dropbox.tsx
@@ -1,0 +1,52 @@
+import { Box, DropZone, DropZoneItem, Label } from "@adminjs/design-system";
+import { BasePropertyProps } from "adminjs";
+import { File } from "node:buffer";
+import React, { FC } from "react";
+
+async function fileToBase64(file: File): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  return Buffer.from(buffer).toString("base64");
+}
+
+//Maximum file size allowed in dropbox in MB
+const MAX_FILE_SIZE = 1024 * 1024 * 5;
+//MIME types that the dropbox will allow to upload
+const ALLOWED_FILE_TYPES = ["image/png", "image/jpeg", "image/webp"];
+
+const PhotoDropbox: FC<BasePropertyProps> = (props) => {
+  const [preview, setPreview] = React.useState<string | undefined>(undefined);
+  const { property, onChange } = props;
+  if (onChange === undefined) {
+    throw new Error("Invalid dropbox configuration. onChange is not defined.");
+  }
+  const handleChange = (files: File[]): void => {
+    if (files.length > 0) {
+      void fileToBase64(files[0]).then((bs) =>
+        setPreview(`data:image/jpeg;base64,${bs}`),
+      );
+      onChange(property.name, files[0]);
+    } else {
+      setPreview(undefined);
+      onChange(property.name, null);
+    }
+  };
+
+  return (
+    <Box>
+      <Label>{property.label}</Label>
+      <DropZone
+        onChange={handleChange}
+        multiple={false}
+        validate={{ maxSize: MAX_FILE_SIZE, mimeTypes: ALLOWED_FILE_TYPES }}
+      />
+      {preview !== undefined && (
+        <DropZoneItem
+          src={preview}
+          onRemove={() => onChange(property.name, null)}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default PhotoDropbox;

--- a/app/admin/components/photo_dropbox.tsx
+++ b/app/admin/components/photo_dropbox.tsx
@@ -1,12 +1,7 @@
-import { Box, DropZone, DropZoneItem, Label } from "@adminjs/design-system";
+import { Box, DropZone, Label } from "@adminjs/design-system";
 import { BasePropertyProps } from "adminjs";
 import { File } from "node:buffer";
 import React, { FC } from "react";
-
-async function fileToBase64(file: File): Promise<string> {
-  const buffer = await file.arrayBuffer();
-  return Buffer.from(buffer).toString("base64");
-}
 
 //Maximum file size allowed in dropbox in MB
 const MAX_FILE_SIZE = 1024 * 1024 * 5;
@@ -14,19 +9,14 @@ const MAX_FILE_SIZE = 1024 * 1024 * 5;
 const ALLOWED_FILE_TYPES = ["image/png", "image/jpeg", "image/webp"];
 
 const PhotoDropbox: FC<BasePropertyProps> = (props) => {
-  const [preview, setPreview] = React.useState<string | undefined>(undefined);
   const { property, onChange } = props;
   if (onChange === undefined) {
     throw new Error("Invalid dropbox configuration. onChange is not defined.");
   }
   const handleChange = (files: File[]): void => {
     if (files.length > 0) {
-      void fileToBase64(files[0]).then((bs) =>
-        setPreview(`data:image/jpeg;base64,${bs}`),
-      );
       onChange(property.name, files[0]);
     } else {
-      setPreview(undefined);
       onChange(property.name, null);
     }
   };
@@ -39,12 +29,6 @@ const PhotoDropbox: FC<BasePropertyProps> = (props) => {
         multiple={false}
         validate={{ maxSize: MAX_FILE_SIZE, mimeTypes: ALLOWED_FILE_TYPES }}
       />
-      {preview !== undefined && (
-        <DropZoneItem
-          src={preview}
-          onRemove={() => onChange(property.name, null)}
-        />
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
# Part 2 out of 3 for feat(AdminPanel): upload photos
Currently the component is not visible anywhere - it will be linked to models in part 3 of this pull request series.
It will look exactly like this, displaying the preview of selected image:
![image](https://github.com/user-attachments/assets/5d31f6f6-1272-4976-b8d8-bd295026e2c7)
