### PR TITLE
feat(departments): added link names to departmentLinks

### DIFF
--- a/app/models/department_link.ts
+++ b/app/models/department_link.ts
@@ -21,6 +21,9 @@ export default class DepartmentsLink extends BaseModel {
   @typedColumn({ type: "string" })
   declare link: string;
 
+  @typedColumn({ type: "string" })
+  declare name: string;
+
   @typedColumn.dateTime({ autoCreate: true })
   declare createdAt: DateTime;
 

--- a/database/migrations/1744906324595_add_department_link_names_table.ts
+++ b/database/migrations/1744906324595_add_department_link_names_table.ts
@@ -1,0 +1,19 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "departments_links";
+  protected defaultName = "Unknown";
+  protected nameColumn = "name";
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string(this.nameColumn).defaultTo(this.defaultName).notNullable();
+    });
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn(this.nameColumn);
+    });
+  }
+}

--- a/database/scrapers/departments.ts
+++ b/database/scrapers/departments.ts
@@ -40,6 +40,7 @@ interface DepartmentLinkDraft {
   department_id: number | null;
   linkType: string;
   link: string;
+  name: string;
 }
 
 export default class DepartmentsScraper extends BaseScraperModule {
@@ -182,6 +183,7 @@ export default class DepartmentsScraper extends BaseScraperModule {
             departmentId: linkEntry.department_id,
             linkType: this.detectLinkType(linkEntry.link),
             link: linkEntry.link,
+            name: linkEntry.name,
             createdAt: DateTime.now(),
             updatedAt: DateTime.now(),
           },

--- a/database/seeders/department_seeder.ts
+++ b/database/seeders/department_seeder.ts
@@ -37,16 +37,19 @@ export default class extends BaseSeeder {
       {
         departmentId: 1,
         linkType: LinkType.TopwrBuildings,
+        name: "Link to B-42",
         link: "topwr:buildings/42",
       },
       {
         departmentId: 1,
         linkType: LinkType.Default,
+        name: "Link to WA",
         link: "http://wa.pwr.edu.pl",
       },
       {
         departmentId: 2,
         linkType: LinkType.TopwrBuildings,
+        name: "Link to B-28",
         link: "topwr:buildings/28",
       },
       {


### PR DESCRIPTION
Works with scrapers, seeders, admin panel, and endpoints. Called the field `name` to keep the convention from Directus