### PR TITLE
fix: add weekday enum values to regular hours res

### DIFF
--- a/app/admin/resources/resource_registers/buildings.ts
+++ b/app/admin/resources/resource_registers/buildings.ts
@@ -1,5 +1,6 @@
 import { buildingIconEnumsValues } from "#enums/building_icon";
 import { externalDigitalGuideModeEnumsValues } from "#enums/digital_guide_mode";
+import { weekdayEnumValues } from "#enums/weekday";
 import Aed from "#models/aed";
 import BicycleShower from "#models/bicycle_shower";
 import Building from "#models/building";
@@ -46,7 +47,12 @@ export const BuildingsBuilder: ResourceBuilder = {
       forModel: Library,
       addImageHandlingForProperties: ["photoKey"],
     },
-    { forModel: RegularHour },
+    {
+      forModel: RegularHour,
+      additionalProperties: {
+        weekDay: weekdayEnumValues,
+      },
+    },
     { forModel: SpecialHour },
   ],
   navigation,


### PR DESCRIPTION
The regular hours resource was missing enum values in additional properties so select was not seeing them