### PR TITLE
fix(models): add validators for time fields

### DIFF
--- a/app/models/regular_hour.ts
+++ b/app/models/regular_hour.ts
@@ -1,3 +1,4 @@
+import vine from "@vinejs/vine";
 import { DateTime } from "luxon";
 
 import { BaseModel, belongsTo } from "@adonisjs/lucid/orm";
@@ -8,6 +9,7 @@ import { Weekday } from "#enums/weekday";
 import { preloadRelations } from "#scopes/preload_helper";
 import { handleSearchQuery } from "#scopes/search_helper";
 import { handleSortQuery } from "#scopes/sort_helper";
+import { TIME_REGEX } from "#validators/time";
 
 import Library from "./library.js";
 
@@ -18,10 +20,16 @@ export default class RegularHour extends BaseModel {
   @typedColumn({ type: Weekday })
   declare weekDay: Weekday;
 
-  @typedColumn({ type: "string" })
+  @typedColumn({
+    type: "string",
+    validator: vine.string().trim().regex(TIME_REGEX),
+  })
   declare openTime: string;
 
-  @typedColumn({ type: "string" })
+  @typedColumn({
+    type: "string",
+    validator: vine.string().trim().regex(TIME_REGEX),
+  })
   declare closeTime: string;
 
   @typedColumn({ foreignKeyOf: () => Library })

--- a/app/models/special_hour.ts
+++ b/app/models/special_hour.ts
@@ -1,3 +1,4 @@
+import vine from "@vinejs/vine";
 import { DateTime } from "luxon";
 
 import { BaseModel, belongsTo } from "@adonisjs/lucid/orm";
@@ -7,6 +8,7 @@ import { typedColumn } from "#decorators/typed_model";
 import { preloadRelations } from "#scopes/preload_helper";
 import { handleSearchQuery } from "#scopes/search_helper";
 import { handleSortQuery } from "#scopes/sort_helper";
+import { TIME_REGEX } from "#validators/time";
 
 import Library from "./library.js";
 
@@ -19,10 +21,16 @@ export default class SpecialHour extends BaseModel {
   })
   declare specialDate: DateTime;
 
-  @typedColumn({ type: "string" })
+  @typedColumn({
+    type: "string",
+    validator: vine.string().trim().regex(TIME_REGEX),
+  })
   declare openTime: string;
 
-  @typedColumn({ type: "string" })
+  @typedColumn({
+    type: "string",
+    validator: vine.string().trim().regex(TIME_REGEX),
+  })
   declare closeTime: string;
 
   @typedColumn({ foreignKeyOf: () => Library })

--- a/app/validators/time.ts
+++ b/app/validators/time.ts
@@ -1,0 +1,1 @@
+export const TIME_REGEX = /^([01]\d:|2[0-3]:)[0-5]\d(:[0-5]\d)?$/;


### PR DESCRIPTION
while reviewing #171 i found out that it's actually quite easy to cause a database error by simply entering an invalid time value, as we don't validate it at all
so i cooked up a regex that should validate any time values before they cause an unexpected error