### PR TITLE
ci: auto-assign PR author if noone was assigned during PR creation

### DIFF
--- a/.github/workflows/pr_automation.yml
+++ b/.github/workflows/pr_automation.yml
@@ -1,0 +1,21 @@
+name: Pull request automation
+
+on:
+  pull_request_target:
+    type: opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign_to_author:
+    name: Assign author if no assignee set
+    if: ${{ github.event.pull_request.assignee == null }}
+    runs-on: ubuntu-latest
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Assign the author to the pull request
+        run: gh pr edit "$PR_URL" --add-assignee $PR_AUTHOR


### PR DESCRIPTION
as title states - this PR adds a new github action that automatically assigns the PR author to any new PRs, unless someone else was assigned during the PR creation
tested on my private action testing repo