### PR TITLE
feat: request metrics

### DIFF
--- a/app/middleware/metrics_middleware.ts
+++ b/app/middleware/metrics_middleware.ts
@@ -1,0 +1,195 @@
+import { HttpContext } from "@adonisjs/core/http";
+import { NextFn } from "@adonisjs/core/types/http";
+
+import "#utils/maps";
+
+interface RouteTimingEntry {
+  timestamp: number;
+  // ms
+  timeElapsed: number;
+}
+
+interface MetricsHttpContextExtras {
+  extras?: {
+    startTime?: number;
+    recorded?: true;
+  } & Record<string, unknown>;
+}
+
+class Metrics {
+  requestCount = 0;
+  requestTimingHistory: RouteTimingEntry[] = [];
+
+  clearOldTimings() {
+    const now = Date.now();
+    let shifted;
+    do {
+      shifted = this.requestTimingHistory.shift();
+    } while (
+      shifted !== undefined &&
+      now - shifted.timestamp > HISTORY_RETAIN_DURATION
+    );
+
+    if (shifted !== undefined) {
+      this.requestTimingHistory.unshift(shifted);
+    }
+  }
+}
+
+const HISTORY_RETAIN_DURATION = 60 * 1000;
+
+// route pattern -> http method -> response status -> metrics object
+export const metrics = new Map<string, Map<string, Map<number, Metrics>>>();
+
+export function recordResponse(ctx: HttpContext & MetricsHttpContextExtras) {
+  // ensure we don't record the same response twice
+  ctx.extras ??= {};
+  if (ctx.extras.recorded === true) {
+    return;
+  }
+  ctx.extras.recorded = true;
+  const { request, response, route, extras } = ctx;
+
+  // record response timing
+  const timeElapsed =
+    extras.startTime !== undefined
+      ? performance.now() - extras.startTime
+      : undefined;
+
+  // get the right metrics bucket
+  const metricsEntry = metrics
+    .getOrInsertWith(route?.pattern ?? "invalid route", () => new Map())
+    .getOrInsertWith(request.method(), () => new Map())
+    .getOrInsertWith(response.getStatus(), () => new Metrics());
+
+  // record response
+  metricsEntry.requestCount += 1;
+  if (timeElapsed !== undefined) {
+    metricsEntry.clearOldTimings();
+    metricsEntry.requestTimingHistory.push({
+      timestamp: Date.now(),
+      timeElapsed,
+    });
+  }
+}
+
+interface Summary {
+  quantiles: Record<string, number>;
+  sum: number;
+  count: number;
+}
+
+const QUANTILES: [number, string][] = [
+  [0.1, "0.1"],
+  [0.25, "0.25"],
+  [0.5, "0.5"],
+  [0.75, "0.75"],
+  [0.9, "0.9"],
+  [0.95, "0.95"],
+  [0.99, "0.99"],
+];
+
+function calculateSummary(sorted: number[]): Summary {
+  const result: Summary = {
+    quantiles: {},
+    sum: sorted.reduce((acc, cur) => acc + cur, 0),
+    count: sorted.length,
+  };
+
+  for (const [quantNum, quantStr] of QUANTILES) {
+    const idx = Math.ceil(quantNum * sorted.length) - 1;
+    result.quantiles[quantStr] = sorted[idx];
+  }
+
+  return result;
+}
+
+export function emitMetrics(): string {
+  const result: string[] = [
+    "# HELP solvronis_global_response_timings A summary of response timings for requests made to all endpoints, in ms",
+    "# TYPE solvronis_global_response_timings summary",
+    "# HELP solvronis_route_response_timings A summary of response timings for requests made to a particular route, in ms",
+    "# TYPE solvronis_route_response_timings summary",
+    "# HELP solvronis_route_status_response_timings A summary of response timings for requests made to a particular route that resulted in a specific status code, in ms",
+    "# TYPE solvronis_route_status_response_timings summary",
+    "# HELP solvronis_route_request_count Count of all requests made to a particular route that resulted in a specific status code",
+    "# TYPE solvronis_route_request_count counter",
+  ];
+
+  const globalTimings: number[][] = [];
+  for (const [routeName, routeBuckets] of metrics.entries()) {
+    for (const [method, methodBuckets] of routeBuckets.entries()) {
+      const routeTimings: number[][] = [];
+      for (const [status, statusBucket] of methodBuckets.entries()) {
+        statusBucket.clearOldTimings();
+        result.push(
+          `solvronis_route_request_count{route="${routeName}", method="${method}", status="${status}"} ${statusBucket.requestCount}`,
+        );
+
+        if (statusBucket.requestTimingHistory.length === 0) {
+          continue;
+        }
+        const statusTimings = statusBucket.requestTimingHistory
+          .map((h) => h.timeElapsed)
+          .sort((a, b) => a - b);
+        routeTimings.push(statusTimings);
+        const summary = calculateSummary(statusTimings);
+
+        for (const [quantile, value] of Object.entries(summary.quantiles)) {
+          result.push(
+            `solvronis_route_status_response_timings{route="${routeName}", method="${method}", status="${status}", quantile="${quantile}"} ${value}`,
+          );
+        }
+        result.push(
+          `solvronis_route_status_response_timings_sum{route="${routeName}", method="${method}", status="${status}"} ${summary.sum}`,
+        );
+        result.push(
+          `solvronis_route_status_response_timings_count{route="${routeName}", method="${method}", status="${status}"} ${summary.count}`,
+        );
+      }
+
+      if (routeTimings.length === 0) {
+        continue;
+      }
+      const routeFlattened = routeTimings.flat().sort((a, b) => a - b);
+      globalTimings.push(routeFlattened);
+      const summary = calculateSummary(routeFlattened);
+
+      for (const [quantile, value] of Object.entries(summary.quantiles)) {
+        result.push(
+          `solvronis_route_response_timings{route="${routeName}", method="${method}", quantile="${quantile}"} ${value}`,
+        );
+      }
+      result.push(
+        `solvronis_route_response_timings_sum{route="${routeName}", method="${method}"} ${summary.sum}`,
+      );
+      result.push(
+        `solvronis_route_response_timings_count{route="${routeName}", method="${method}"} ${summary.count}`,
+      );
+    }
+  }
+
+  if (globalTimings.length > 0) {
+    const globalFlattened = globalTimings.flat().sort((a, b) => a - b);
+    const summary = calculateSummary(globalFlattened);
+
+    for (const [quantile, value] of Object.entries(summary.quantiles)) {
+      result.push(
+        `solvronis_global_response_timings{quantile="${quantile}"} ${value}`,
+      );
+    }
+    result.push(`solvronis_global_response_timings_sum ${summary.sum}`);
+    result.push(`solvronis_global_response_timings_count ${summary.count}`);
+  }
+
+  return result.join("\n");
+}
+
+export default class MetricsMiddleware {
+  async handle(ctx: HttpContext & MetricsHttpContextExtras, next: NextFn) {
+    ctx.extras ??= {};
+    ctx.extras.startTime = performance.now();
+    await next();
+    recordResponse(ctx);
+  }
+}

--- a/start/kernel.ts
+++ b/start/kernel.ts
@@ -25,6 +25,7 @@ server.errorHandler(() => import("#exceptions/handler"));
  * the request URL.
  */
 server.use([
+  () => import("#middleware/metrics_middleware"),
   () => import("#middleware/container_bindings_middleware"),
   () => import("#middleware/force_json_response_middleware"),
   () => import("@adonisjs/cors/cors_middleware"),

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -58,6 +58,11 @@ router.get("/", async () => {
   return { appName: env.get("APP_NAME"), version: env.get("APP_VERSION") };
 });
 
+router.get("/metrics", async () => {
+  const { emitMetrics } = await import("#middleware/metrics_middleware");
+  return emitMetrics();
+});
+
 router
   .group(() => {
     router


### PR DESCRIPTION
this commit adds a /metrics endpoint which exposes the number of requests for any given route and a summary of response timings for the last 60 seconds.
all of this is formatted in a way that prometheus should understand (but i didn't actually test that part, we test that on prod)

stuff to do after merging:
- hook up a prometheus instance to scrape the metrics
- verify that the metrics are formatted correctly
- make a grafana dashboard