### PR TITLE
refactor(dockerfile): various optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,37 @@ FROM node:22.14.0-alpine3.21 AS base
 WORKDIR /app
 ADD package.json package-lock.json ./
 
-# All deps stage
-FROM base AS dev-deps
-RUN npm ci
-
 # Production only deps stage
 FROM base AS prod-deps
-RUN npm ci --omit=dev
+# try to do a regular install (as it doesn't remove the existing node_modules dir)
+# then diff the package-lock - if it changed, do a clean install instead
+RUN --mount=type=cache,dst=/root/.npm \
+    --mount=type=cache,dst=/tmp/node-compile-cache \
+    cp package-lock.json package-lock.json.old && \
+    npm i --omit=dev --ignore-scripts --no-audit --no-fund && \
+    (diff package-lock.json package-lock.json.old > /dev/null || npm ci --omit=dev --ignore-scripts --no-audit --no-fund) && \
+    rm package-lock.json.old
 
-# Build stage
-FROM dev-deps AS build
-ADD . .
-RUN node ace build
+# All deps stage
+FROM prod-deps AS dev-deps
+RUN --mount=type=cache,dst=/root/.npm \
+    --mount=type=cache,dst=/tmp/node-compile-cache/ \
+    cp package-lock.json package-lock.json.old && \
+    npm i --ignore-scripts --no-audit --no-fund && \
+    (diff package-lock.json package-lock.json.old > /dev/null || npm ci --ignore-scripts --no-audit --no-fund) && \
+    rm package-lock.json.old
 
 # Production stage
 FROM prod-deps
+# docker mount magic: mount the context dir into /source, mount devdeps into /source/node_modules, mount tmpfs on /tmp to omit tmp files from the image
+#  start the build, then move build files into the image - no copying between stages 😎
+RUN --mount=type=bind,dst=/source,rw \
+    --mount=type=bind,from=dev-deps,source=/app/node_modules,dst=/source/node_modules \
+    --mount=type=tmpfs,dst=/tmp \
+    cd /source &&\
+    node ace build &&\
+    rm /source/build/package.json /source/build/package-lock.json &&\
+    mv /source/build/* /app
 ENV NODE_ENV=production
-COPY --from=build /app/build /app
 EXPOSE 8080
 CMD ["node", "./bin/server.js"]


### PR DESCRIPTION
these optimizations should speed up build times, slightly reduce image size, and reduce builder cache sizes

things done:
- added cache mounts for npm calls
  - this should speed up build times and reduce final image sizes, as the cache isn't included in the image
- used npm install instead of npm cleaninstall
  - this makes npm not recreate the node_modules dir from scratch
  - the lockfile is diffed for changes and a cleaninstall is done if changes are detected
- moved the prod-deps stage before dev-deps, made dev-deps build from prod-deps
  - this reduces builder cache sizes by ~300MB due to the change mentioned above
- used bind mounts instead of `ADD . .` for building
  - this speeds up build times and reduces builder cache sizes as the project does not need to be copied between the build context and the container layers
- removed the build stage in favour of mount magic in the final stage
  - instead of building in a dedicated stage, the build process occurs in a temporary directory mounted from the build context, with the dev deps also mounted in
  - the output is moved out of the temporary mount into the layer directly
  - this again speeds up build times and reduces builder cache sizes, as copying is relatively expensive and the built files don't need to be stored twice

in local testing with podman, the build time was cut down from 2m 30s to 1m 20s, and the final image was shrunk by ~50MB