### PR TITLE
refactor: set fk actions to restrict

### DIFF
--- a/database/migrations/1755532368818_add_restrict_rules_to_relations.ts
+++ b/database/migrations/1755532368818_add_restrict_rules_to_relations.ts
@@ -6,10 +6,6 @@ export default class extends BaseSchema {
     foreign: string;
     references: string;
     oldAction: string;
-    /*
-     * Adonis autogenerates this from column and table names but there is a mismatch from previous migrations
-     */
-    constraint_name?: string;
   }[] = [
     {
       table: "buildings",
@@ -36,18 +32,6 @@ export default class extends BaseSchema {
       oldAction: "SET NULL",
     },
     {
-      table: "regular_hours",
-      foreign: "library_id",
-      references: "libraries.id",
-      oldAction: "CASCADE",
-    },
-    {
-      table: "special_hours",
-      foreign: "library_id",
-      references: "libraries.id",
-      oldAction: "CASCADE",
-    },
-    {
       table: "bicycle_showers",
       foreign: "building_id",
       references: "buildings.id",
@@ -60,70 +44,9 @@ export default class extends BaseSchema {
       oldAction: "CASCADE",
     },
     {
-      table: "department_links",
-      foreign: "department_id",
-      references: "departments.id",
-      oldAction: "RESTRICT",
-      constraint_name: "departments_links_department_id_foreign", // 1744906324598 changed the name, but the constraint name stayed the same
-    },
-    {
-      table: "day_swaps",
-      foreign: "academic_calendar_id",
-      references: "academic_calendars.id",
-      oldAction: "CASCADE",
-    },
-    {
-      table: "holidays",
-      foreign: "academic_calendar_id",
-      references: "academic_calendars.id",
-      oldAction: "CASCADE",
-    },
-    {
-      table: "contributor_social_links",
-      foreign: "contributor_id",
-      references: "contributors.id",
-      oldAction: "CASCADE",
-    },
-    {
-      table: "changes",
-      foreign: "version_id",
-      references: "versions.id",
-      oldAction: "CASCADE",
-    },
-    {
-      table: "change_screenshots",
-      foreign: "change_id",
-      references: "changes.id",
-      oldAction: "CASCADE",
-    },
-    {
-      table: "version_screenshots",
-      foreign: "version_id",
-      references: "versions.id",
-      oldAction: "CASCADE",
-    },
-    {
-      table: "student_organization_links",
-      foreign: "student_organization_id",
-      references: "student_organizations.id",
-      oldAction: "CASCADE",
-    },
-    {
       table: "guide_questions",
       foreign: "article_id",
       references: "guide_articles.id",
-      oldAction: "CASCADE",
-    },
-    {
-      table: "guide_article_authors",
-      foreign: "article_id",
-      references: "guide_articles.id",
-      oldAction: "CASCADE",
-    },
-    {
-      table: "guide_article_authors",
-      foreign: "author_id",
-      references: "guide_authors.id",
       oldAction: "CASCADE",
     },
   ];
@@ -131,7 +54,7 @@ export default class extends BaseSchema {
   async up() {
     for (const constraint of this.constraints) {
       this.schema.alterTable(constraint.table, (table) => {
-        table.dropForeign(constraint.foreign, constraint.constraint_name);
+        table.dropForeign(constraint.foreign);
         table
           .foreign(constraint.foreign)
           .references(constraint.references)
@@ -145,7 +68,7 @@ export default class extends BaseSchema {
       this.schema.alterTable(constraint.table, (table) => {
         table.dropForeign(constraint.foreign);
         table
-          .foreign(constraint.foreign, constraint.constraint_name)
+          .foreign(constraint.foreign)
           .references(constraint.references)
           .onDelete(constraint.oldAction);
       });

--- a/database/migrations/1755532368818_add_restrict_rules_to_relations.ts
+++ b/database/migrations/1755532368818_add_restrict_rules_to_relations.ts
@@ -1,0 +1,154 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected readonly constraints: {
+    table: string;
+    foreign: string;
+    references: string;
+    oldAction: string;
+    /*
+     * Adonis autogenerates this from column and table names but there is a mismatch from previous migrations
+     */
+    constraint_name?: string;
+  }[] = [
+    {
+      table: "buildings",
+      foreign: "campus_id",
+      references: "campuses.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "food_spots",
+      foreign: "building_id",
+      references: "buildings.id",
+      oldAction: "SET NULL",
+    },
+    {
+      table: "aeds",
+      foreign: "building_id",
+      references: "buildings.id",
+      oldAction: "SET NULL",
+    },
+    {
+      table: "libraries",
+      foreign: "building_id",
+      references: "buildings.id",
+      oldAction: "SET NULL",
+    },
+    {
+      table: "regular_hours",
+      foreign: "library_id",
+      references: "libraries.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "special_hours",
+      foreign: "library_id",
+      references: "libraries.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "bicycle_showers",
+      foreign: "building_id",
+      references: "buildings.id",
+      oldAction: "SET NULL",
+    },
+    {
+      table: "fields_of_studies",
+      foreign: "department_id",
+      references: "departments.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "department_links",
+      foreign: "department_id",
+      references: "departments.id",
+      oldAction: "RESTRICT",
+      constraint_name: "departments_links_department_id_foreign", // 1744906324598 changed the name, but the constraint name stayed the same
+    },
+    {
+      table: "day_swaps",
+      foreign: "academic_calendar_id",
+      references: "academic_calendars.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "holidays",
+      foreign: "academic_calendar_id",
+      references: "academic_calendars.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "contributor_social_links",
+      foreign: "contributor_id",
+      references: "contributors.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "changes",
+      foreign: "version_id",
+      references: "versions.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "change_screenshots",
+      foreign: "change_id",
+      references: "changes.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "version_screenshots",
+      foreign: "version_id",
+      references: "versions.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "student_organization_links",
+      foreign: "student_organization_id",
+      references: "student_organizations.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "guide_questions",
+      foreign: "article_id",
+      references: "guide_articles.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "guide_article_authors",
+      foreign: "article_id",
+      references: "guide_articles.id",
+      oldAction: "CASCADE",
+    },
+    {
+      table: "guide_article_authors",
+      foreign: "author_id",
+      references: "guide_authors.id",
+      oldAction: "CASCADE",
+    },
+  ];
+
+  async up() {
+    for (const constraint of this.constraints) {
+      this.schema.alterTable(constraint.table, (table) => {
+        table.dropForeign(constraint.foreign, constraint.constraint_name);
+        table
+          .foreign(constraint.foreign)
+          .references(constraint.references)
+          .onDelete("RESTRICT");
+      });
+    }
+  }
+
+  async down() {
+    for (const constraint of this.constraints) {
+      this.schema.alterTable(constraint.table, (table) => {
+        table.dropForeign(constraint.foreign);
+        table
+          .foreign(constraint.foreign, constraint.constraint_name)
+          .references(constraint.references)
+          .onDelete(constraint.oldAction);
+      });
+    }
+  }
+}


### PR DESCRIPTION
According to the issue i changed all the foreign key constraints to restrict, except those that are on the pivot table.

There where some doubts though, on my side, regarding some of the tables that actually could benefit from **CASCADE** on delete such as `regular_hours` deletion alongside the `library` etc. But i understand that it can be solved with either incremental deletion on frontend side, or just a transaction on backend side, and the restrict behaviour is far safer than the cascade

This is sql statement to fetch all non restrict constraints on the tables:

```sql
SELECT conrelid::regclass AS table_name,
       conname AS constraint_name,
       confrelid::regclass AS referenced_table_name,
       pg_get_constraintdef(oid)
FROM   pg_constraint
WHERE  contype = 'f'
AND    confdeltype <> 'r';
```

with the result of:
<img width="2391" height="536" alt="obraz" src="https://github.com/user-attachments/assets/7ca525e5-3a78-400e-82e6-5ce02bc25694" />

23 rows, 4 of which belonged to the pivot tables:
- contributor_roles - contributor_roles_contributor_id_foreign
- student_organizations_student_organization_tags - student_organizations_student_organization_tags_student_organiz
- student_organizations_student_organization_tags - student_organizations_student_organization_tags_tag_foreign
- auth_access_tokens - auth_access_tokens_tokenable_id_foreign

P.S.
While doing the task, i noticed that there are some foreign keys that are not autogenerated in the referenced table, that could be changed in the future, and there are no **onUpdate** (the default pg rule is `NOACTION`) rules, so the relations between them can break. Maybe it's a good idea for another task
