### PR TITLE
feat(models): order fields

### DIFF
--- a/app/models/contributor.ts
+++ b/app/models/contributor.ts
@@ -28,6 +28,9 @@ export default class Contributor extends BaseModel {
   @typedColumn({ foreignKeyOf: () => FileEntry, optional: true })
   declare photoKey: string | null;
 
+  @typedColumn({ type: "number" })
+  declare order: number;
+
   @typedColumn.dateTime({ autoCreate: true })
   declare createdAt: DateTime;
 

--- a/app/models/guide_article.ts
+++ b/app/models/guide_article.ts
@@ -30,6 +30,9 @@ export default class GuideArticle extends BaseModel {
   @typedColumn({ type: "string" })
   declare description: string;
 
+  @typedColumn({ type: "number" })
+  declare order: number;
+
   @typedColumn({ foreignKeyOf: () => FileEntry })
   declare imageKey: string;
 

--- a/app/models/guide_question.ts
+++ b/app/models/guide_question.ts
@@ -19,6 +19,9 @@ export default class GuideQuestion extends BaseModel {
   @typedColumn({ type: "string" })
   declare answer: string;
 
+  @typedColumn({ type: "number" })
+  declare order: number;
+
   @typedColumn({ foreignKeyOf: () => GuideArticle })
   declare articleId: number;
 

--- a/commands/db_normalize_order.ts
+++ b/commands/db_normalize_order.ts
@@ -1,0 +1,46 @@
+import { BaseCommand, flags } from "@adonisjs/core/ace";
+import type { CommandOptions } from "@adonisjs/core/types/ace";
+
+import { normalizeOrderField } from "#utils/db";
+
+export default class DbNormalizeOrder extends BaseCommand {
+  static commandName = "db:normalize-order";
+  static description =
+    "Replaces the order columns with a fresh integer sequence, keeping the entry order unchanged";
+  private orderedTables = ["contributors", "guide_articles", "guide_questions"];
+
+  static options: CommandOptions = {
+    startApp: true,
+  };
+
+  @flags.boolean({
+    description: "Don't ask for confirmation",
+  })
+  declare force: boolean;
+
+  async run() {
+    if (this.force) {
+      this.logger.warning("Force flag passed - confirmation skipped");
+    } else {
+      const confirmation = await this.prompt.confirm(
+        "Warning: this command will update order fields for all applicable tables. The frontend might malfunction if someone is currently viewing/editing ordered tables. Continue?",
+        { default: false },
+      );
+      if (!confirmation) {
+        this.logger.info("Cancelled.");
+        this.exitCode = 1;
+        return;
+      }
+    }
+
+    const tasks = this.ui.tasks();
+    for (const table of this.orderedTables) {
+      tasks.add(`Normalize order for table "${table}"`, async () => {
+        await normalizeOrderField(table);
+        return "done";
+      });
+    }
+    await tasks.run();
+    this.exitCode = tasks.getState() === "succeeded" ? 0 : 1;
+  }
+}

--- a/database/migrations/1758982174631_add_order_fields.ts
+++ b/database/migrations/1758982174631_add_order_fields.ts
@@ -1,0 +1,30 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tables = ["contributors", "guide_articles", "guide_questions"];
+
+  async up() {
+    for (const tableName of this.tables) {
+      this.schema.raw(
+        `
+        ALTER TABLE "${tableName}"
+          ADD COLUMN "order" REAL NULL;
+
+        UPDATE "${tableName}"
+        SET "order" = "id";
+
+        ALTER TABLE "${tableName}"
+          ALTER COLUMN "order" SET NOT NULL;
+      `,
+      );
+    }
+  }
+
+  async down() {
+    for (const tableName of this.tables) {
+      this.schema.alterTable(tableName, (table) => {
+        table.dropColumn("order");
+      });
+    }
+  }
+}


### PR DESCRIPTION
closes #239

this pr adds basically everything that was listed in the issue:
- float order columns for the applicable tables
- and a script that normalizes the values by generating new order values in a temporary table