### PR TITLE
refactor: base controller split

### DIFF
--- a/app/controllers/auto_crud_controller.ts
+++ b/app/controllers/auto_crud_controller.ts
@@ -1009,7 +1009,7 @@ export default abstract class AutoCrudController<
     const mainInstance = await this.getFirstOrFail(id);
     await this.authorizeRecord(
       { request, route, auth } as unknown as HttpContext,
-      "oneToManyRelationStore",
+      "oneToOneRelationStore",
       mainInstance,
     );
 

--- a/app/controllers/auto_crud_controller.ts
+++ b/app/controllers/auto_crud_controller.ts
@@ -1,8 +1,6 @@
 import adonisString from "@poppinss/utils/string";
 import { BaseError } from "@solvro/error-handling/base";
 import assert from "node:assert";
-import type { Dirent } from "node:fs";
-import fs from "node:fs/promises";
 
 import type { HttpContext } from "@adonisjs/core/http";
 import logger from "@adonisjs/core/services/logger";
@@ -29,6 +27,7 @@ import type {
   ManyToManyRelationContract,
 } from "@adonisjs/lucid/types/relations";
 
+import BaseController from "#controllers/base_controller";
 import {
   validateColumnDef,
   validateTypedManyToManyRelation,
@@ -116,8 +115,6 @@ export type DeleteHookContext<T extends LucidModel> = Omit<
   "request"
 >;
 
-const LOADABLE_EXTENSIONS = [".js", ".ts"];
-
 /**
  * Additional configuration options for the BaseController.$configureRoutes.
  * `skipRoutes` property: if a route should be skipped, set it to true. Defaults to false
@@ -149,7 +146,7 @@ export type ControllerAction =
 
 export default abstract class AutoCrudController<
   T extends LucidModel & Scopes<LucidModel>,
-> {
+> extends BaseController {
   /**
    * Relations which should be supported in queries
    * Supports nested relations
@@ -171,10 +168,6 @@ export default abstract class AutoCrudController<
    * the id as an url parameter, using this value to look up the instance instead.
    */
   protected readonly singletonId?: number | string;
-  /**
-   * With the default implementation of `authenticate()`, if the user has any of the following roles, the permission checks are skipped.
-   */
-  protected superUserRoles: string[] = ["solvro_admin"];
 
   /**
    * Return the permission slug(s) required for the given action, or null/undefined if none is required.
@@ -223,50 +216,6 @@ export default abstract class AutoCrudController<
       case "relationIndex":
       default:
         return null;
-    }
-  }
-
-  /**
-   * Check whether the current user is a super user.
-   *
-   * Super user roles for a particular controller can be defined in its properties.
-   * This method does not force authentication - unauthenticated users are not considered super users. (obviously lol)
-   * Only one of the defined roles is requred for a user to be considered a super user.
-   *
-   * @param auth the authentication context
-   * @returns true if the user is a super user
-   */
-  protected async isSuperUser(auth: HttpContext["auth"]): Promise<boolean> {
-    // no roles defined - definitely not a superuser then
-    if (this.superUserRoles.length === 0) {
-      return false;
-    }
-    // not logged in - not a super user
-    if (!(await auth.check())) {
-      return false;
-    }
-    // it is known at this point that the user is authenticated
-    assert(auth.user !== undefined);
-    // check for superuser roles
-    return await auth.user.hasAnyRole(...this.superUserRoles);
-  }
-
-  /**
-   * Require that the currently logged in user is a super user
-   *
-   * Super user roles for a particular controller can be defined in its properties.
-   * This method does force authentication and will throw a ForbiddenException if the current user is not a super user.
-   * Only one of the defined roles is requred for a user to be considered a super user.
-   *
-   * @param auth the authentication context
-   * @throws ForbiddenException if the current user is not a super user
-   */
-  protected async requireSuperUser(auth: HttpContext["auth"]): Promise<void> {
-    if (!auth.isAuthenticated) {
-      await auth.authenticate();
-    }
-    if (!(await this.isSuperUser(auth))) {
-      throw new ForbiddenException();
     }
   }
 
@@ -633,142 +582,6 @@ export default abstract class AutoCrudController<
     throw selfValidationResult;
   }
 
-  /**
-   * Generates a configuration callback for a controller using its lazy import
-   */
-  static async configureRoutes(
-    controller: LazyImport<Constructor<unknown>>,
-    debugName: string,
-  ): Promise<() => void> {
-    const imported = await controller();
-    const ControllerCtor = imported.default as new (
-      ...args: unknown[]
-    ) => unknown;
-    const instance: unknown = new ControllerCtor();
-    if (!(instance instanceof AutoCrudController)) {
-      const maybeRoutes = instance as {
-        $configureRoutes?: (
-          controller: LazyImport<Constructor<unknown>>,
-        ) => () => void;
-      };
-      if (
-        !(
-          typeof maybeRoutes.$configureRoutes === "function" &&
-          maybeRoutes.$configureRoutes.length === 1
-        )
-      ) {
-        throw new Error(
-          `Attempted to configure routes for a non-BaseController-based controller which does not implement $configureRoutes: ${debugName}`,
-        );
-      }
-      logger.warn(
-        `Configuring routes for a non-BaseController-based controller: ${debugName}`,
-      );
-      return maybeRoutes.$configureRoutes.bind(
-        maybeRoutes,
-        controller as LazyImport<Constructor<object>>,
-      );
-    }
-    const baseInstance = instance as AutoCrudController<
-      LucidModel & Scopes<LucidModel>
-    >;
-    return baseInstance.$configureRoutes.bind(
-      baseInstance,
-      controller as LazyImport<
-        Constructor<AutoCrudController<LucidModel & Scopes<LucidModel>>>
-      >,
-    );
-  }
-
-  /**
-   * Generates a configuration callback that configures each of the named controllers
-   */
-  static async configureByNames(paths: string[]): Promise<() => void> {
-    const toConfigure: [string, () => void][] = await Promise.all(
-      paths.map(async (path) => {
-        const controller = (async () =>
-          await import(`#controllers/${path}`)) as LazyImport<
-          Constructor<unknown>
-        >;
-        return [
-          path,
-          await AutoCrudController.configureRoutes(controller, path),
-        ];
-      }),
-    );
-    return () => {
-      for (const [path, config] of toConfigure) {
-        const name = path.split("/").at(-1) ?? path;
-        router.group(config).prefix(`/${name}`).as(name);
-      }
-    };
-  }
-
-  /**
-   * Configures all controller routes automatically
-   */
-  static async configureAll(): Promise<void> {
-    // find all version directories
-    let version = 0;
-    // map endpoint names to version directories
-    // allows new API versions to inherit from earlier ones without symlinks or code duplication
-    const currentEndpoints = new Map<string, number>();
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    while (true) {
-      // iterate while directories for each version exist
-      const dir = `./app/controllers/v${++version}`;
-      try {
-        const statResult = await fs.stat(dir);
-        if (!statResult.isDirectory()) {
-          break;
-        }
-      } catch {
-        break;
-      }
-
-      // list directory files for the version
-      const verDirReader = await fs.opendir(dir);
-      let controllerFile: Dirent | null = null;
-      while ((controllerFile = await verDirReader.read()) !== null) {
-        // skip non-files
-        if (!controllerFile.isFile()) {
-          continue;
-        }
-        for (const ext of LOADABLE_EXTENSIONS) {
-          // find the correct extension for the file
-          if (!controllerFile.name.endsWith(ext)) {
-            continue;
-          }
-          // add to list
-          currentEndpoints.set(
-            controllerFile.name.substring(
-              0,
-              controllerFile.name.length - ext.length,
-            ),
-            version,
-          );
-          break;
-        }
-      }
-      await verDirReader.close();
-
-      // configure
-      const configureVersion = await AutoCrudController.configureByNames(
-        currentEndpoints
-          .entries()
-          .map(([name, ver]) => `v${ver}/${name}`)
-          .toArray(),
-      );
-      router
-        .group(configureVersion)
-        .prefix(`/api/v${version}`)
-        .as(`v${version}`);
-    }
-  }
-
-  /**
-   * Configures routes for this controller when passed as the group callback
-   */
   $configureRoutes(
     controller: LazyImport<Constructor<AutoCrudController<T>>>,
     configurationOptions?: RouteConfigurationOptions,

--- a/app/controllers/auto_crud_controller.ts
+++ b/app/controllers/auto_crud_controller.ts
@@ -437,7 +437,7 @@ export default abstract class AutoCrudController<
   /**
    * The actual self-validation function, does not cache!
    */
-  protected async doSelfValidate(): Promise<InternalControllerValidationError | null> {
+  public async doSelfValidate(): Promise<InternalControllerValidationError | null> {
     const issues = [];
 
     // Verify scopes

--- a/app/controllers/auto_crud_controller.ts
+++ b/app/controllers/auto_crud_controller.ts
@@ -147,7 +147,7 @@ export type ControllerAction =
 
 // Use the same Constructor type as other controllers (e.g., mobile_config_controller)
 
-export default abstract class BaseController<
+export default abstract class AutoCrudController<
   T extends LucidModel & Scopes<LucidModel>,
 > {
   /**
@@ -645,7 +645,7 @@ export default abstract class BaseController<
       ...args: unknown[]
     ) => unknown;
     const instance: unknown = new ControllerCtor();
-    if (!(instance instanceof BaseController)) {
+    if (!(instance instanceof AutoCrudController)) {
       const maybeRoutes = instance as {
         $configureRoutes?: (
           controller: LazyImport<Constructor<unknown>>,
@@ -669,13 +669,13 @@ export default abstract class BaseController<
         controller as LazyImport<Constructor<object>>,
       );
     }
-    const baseInstance = instance as BaseController<
+    const baseInstance = instance as AutoCrudController<
       LucidModel & Scopes<LucidModel>
     >;
     return baseInstance.$configureRoutes.bind(
       baseInstance,
       controller as LazyImport<
-        Constructor<BaseController<LucidModel & Scopes<LucidModel>>>
+        Constructor<AutoCrudController<LucidModel & Scopes<LucidModel>>>
       >,
     );
   }
@@ -690,7 +690,10 @@ export default abstract class BaseController<
           await import(`#controllers/${path}`)) as LazyImport<
           Constructor<unknown>
         >;
-        return [path, await BaseController.configureRoutes(controller, path)];
+        return [
+          path,
+          await AutoCrudController.configureRoutes(controller, path),
+        ];
       }),
     );
     return () => {
@@ -750,7 +753,7 @@ export default abstract class BaseController<
       await verDirReader.close();
 
       // configure
-      const configureVersion = await BaseController.configureByNames(
+      const configureVersion = await AutoCrudController.configureByNames(
         currentEndpoints
           .entries()
           .map(([name, ver]) => `v${ver}/${name}`)
@@ -767,7 +770,7 @@ export default abstract class BaseController<
    * Configures routes for this controller when passed as the group callback
    */
   $configureRoutes(
-    controller: LazyImport<Constructor<BaseController<T>>>,
+    controller: LazyImport<Constructor<AutoCrudController<T>>>,
     configurationOptions?: RouteConfigurationOptions,
   ) {
     if (this.singletonId === undefined) {
@@ -1419,7 +1422,7 @@ export default abstract class BaseController<
 
     // We can avoid fetching the main instance here since authorization was done pre-DB,
     // but still support row-level authorization hooks when overridden.
-    if (this.authorizeRecord !== BaseController.prototype.authorizeRecord) {
+    if (this.authorizeRecord !== AutoCrudController.prototype.authorizeRecord) {
       const mainInstance = await this.getFirstOrFail(localId);
       await this.authorizeRecord(
         httpCtx,

--- a/app/controllers/base_controller.ts
+++ b/app/controllers/base_controller.ts
@@ -1,14 +1,9 @@
 import { assertDefined } from "@solvro/utils/option";
-import type { Dirent } from "node:fs";
-import * as fs from "node:fs/promises";
 
 import type { HttpContext } from "@adonisjs/core/http";
-import router from "@adonisjs/core/services/router";
 import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
 
 import { ForbiddenException } from "#app/exceptions/http_exceptions";
-
-const LOADABLE_EXTENSIONS = [".js", ".ts"];
 
 export default abstract class BaseController {
   /**
@@ -67,110 +62,4 @@ export default abstract class BaseController {
   abstract $configureRoutes(
     controller: LazyImport<Constructor<BaseController>>,
   ): void;
-
-  /**
-   * Generates a configuration callback for a controller using its lazy import
-   */
-  static async configureRoutes(
-    controller: LazyImport<Constructor<unknown>>,
-    debugName: string,
-  ): Promise<() => void> {
-    const imported = await controller();
-    const ControllerCtor = imported.default as new (
-      ...args: unknown[]
-    ) => unknown;
-    const instance: unknown = new ControllerCtor();
-    if (!(instance instanceof BaseController)) {
-      throw new Error(
-        `Attempted to configure routes for a class that does not extend BaseController: ${debugName}`,
-      );
-    }
-    return instance.$configureRoutes.bind(
-      instance,
-      controller as LazyImport<Constructor<BaseController>>,
-    );
-  }
-
-  /**
-   * Generates a configuration callback that configures each of the named controllers
-   */
-  static async configureByNames(paths: string[]): Promise<() => void> {
-    const toConfigure: [string, () => void][] = await Promise.all(
-      paths.map(async (path) => {
-        const controller = (async () =>
-          await import(`#controllers/${path}`)) as LazyImport<
-          Constructor<unknown>
-        >;
-        return [path, await BaseController.configureRoutes(controller, path)];
-      }),
-    );
-    return () => {
-      for (const [path, config] of toConfigure) {
-        const name = path.split("/").at(-1) ?? path;
-        router.group(config).prefix(`/${name}`).as(name);
-      }
-    };
-  }
-
-  /**
-   * Configures all controller routes automatically
-   */
-  static async configureAll(): Promise<void> {
-    // find all version directories
-    let version = 0;
-    // map endpoint names to version directories
-    // allows new API versions to inherit from earlier ones without symlinks or code duplication
-    const currentEndpoints = new Map<string, number>();
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    while (true) {
-      // iterate while directories for each version exist
-      const dir = `./app/controllers/v${++version}`;
-      try {
-        const statResult = await fs.stat(dir);
-        if (!statResult.isDirectory()) {
-          break;
-        }
-      } catch {
-        break;
-      }
-
-      // list directory files for the version
-      const verDirReader = await fs.opendir(dir);
-      let controllerFile: Dirent | null = null;
-      while ((controllerFile = await verDirReader.read()) !== null) {
-        // skip non-files
-        if (!controllerFile.isFile()) {
-          continue;
-        }
-        for (const ext of LOADABLE_EXTENSIONS) {
-          // find the correct extension for the file
-          if (!controllerFile.name.endsWith(ext)) {
-            continue;
-          }
-          // add to list
-          currentEndpoints.set(
-            controllerFile.name.substring(
-              0,
-              controllerFile.name.length - ext.length,
-            ),
-            version,
-          );
-          break;
-        }
-      }
-      await verDirReader.close();
-
-      // configure
-      const configureVersion = await BaseController.configureByNames(
-        currentEndpoints
-          .entries()
-          .map(([name, ver]) => `v${ver}/${name}`)
-          .toArray(),
-      );
-      router
-        .group(configureVersion)
-        .prefix(`/api/v${version}`)
-        .as(`v${version}`);
-    }
-  }
 }

--- a/app/controllers/base_controller.ts
+++ b/app/controllers/base_controller.ts
@@ -1,0 +1,176 @@
+import { assertDefined } from "@solvro/utils/option";
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+
+import type { HttpContext } from "@adonisjs/core/http";
+import router from "@adonisjs/core/services/router";
+import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
+
+import { ForbiddenException } from "#app/exceptions/http_exceptions";
+
+const LOADABLE_EXTENSIONS = [".js", ".ts"];
+
+export default abstract class BaseController {
+  /**
+   * With the default implementation of `authenticate()`, if the user has any of the following roles, the permission checks are skipped.
+   */
+  protected superUserRoles: string[] = ["solvro_admin"];
+
+  /**
+   * Check whether the current user is a super user.
+   *
+   * Super user roles for a particular controller can be defined in its properties.
+   * This method does not force authentication - unauthenticated users are not considered super users. (obviously lol)
+   * Only one of the defined roles is requred for a user to be considered a super user.
+   *
+   * @param auth the authentication context
+   * @returns true if the user is a super user
+   */
+  protected async isSuperUser(auth: HttpContext["auth"]): Promise<boolean> {
+    // no roles defined - definitely not a superuser then
+    if (this.superUserRoles.length === 0) {
+      return false;
+    }
+    // not logged in - not a super user
+    if (!(await auth.check())) {
+      return false;
+    }
+    // it is known at this point that the user is authenticated
+    assertDefined(auth.user);
+    // check for superuser roles
+    return await auth.user.hasAnyRole(...this.superUserRoles);
+  }
+
+  /**
+   * Require that the currently logged in user is a super user
+   *
+   * Super user roles for a particular controller can be defined in its properties.
+   * This method does force authentication and will throw a ForbiddenException if the current user is not a super user.
+   * Only one of the defined roles is requred for a user to be considered a super user.
+   *
+   * @param auth the authentication context
+   * @throws ForbiddenException if the current user is not a super user
+   */
+  protected async requireSuperUser(auth: HttpContext["auth"]): Promise<void> {
+    if (!auth.isAuthenticated) {
+      await auth.authenticate();
+    }
+    if (!(await this.isSuperUser(auth))) {
+      throw new ForbiddenException();
+    }
+  }
+
+  /**
+   * Configure your routes here using standard adonis router functions.
+   * You will automatically be scoped to your controller path.
+   */
+  abstract $configureRoutes(
+    controller: LazyImport<Constructor<BaseController>>,
+  ): void;
+
+  /**
+   * Generates a configuration callback for a controller using its lazy import
+   */
+  static async configureRoutes(
+    controller: LazyImport<Constructor<unknown>>,
+    debugName: string,
+  ): Promise<() => void> {
+    const imported = await controller();
+    const ControllerCtor = imported.default as new (
+      ...args: unknown[]
+    ) => unknown;
+    const instance: unknown = new ControllerCtor();
+    if (!(instance instanceof BaseController)) {
+      throw new Error(
+        `Attempted to configure routes for a class that does not extend BaseController: ${debugName}`,
+      );
+    }
+    return instance.$configureRoutes.bind(
+      instance,
+      controller as LazyImport<Constructor<BaseController>>,
+    );
+  }
+
+  /**
+   * Generates a configuration callback that configures each of the named controllers
+   */
+  static async configureByNames(paths: string[]): Promise<() => void> {
+    const toConfigure: [string, () => void][] = await Promise.all(
+      paths.map(async (path) => {
+        const controller = (async () =>
+          await import(`#controllers/${path}`)) as LazyImport<
+          Constructor<unknown>
+        >;
+        return [path, await BaseController.configureRoutes(controller, path)];
+      }),
+    );
+    return () => {
+      for (const [path, config] of toConfigure) {
+        const name = path.split("/").at(-1) ?? path;
+        router.group(config).prefix(`/${name}`).as(name);
+      }
+    };
+  }
+
+  /**
+   * Configures all controller routes automatically
+   */
+  static async configureAll(): Promise<void> {
+    // find all version directories
+    let version = 0;
+    // map endpoint names to version directories
+    // allows new API versions to inherit from earlier ones without symlinks or code duplication
+    const currentEndpoints = new Map<string, number>();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    while (true) {
+      // iterate while directories for each version exist
+      const dir = `./app/controllers/v${++version}`;
+      try {
+        const statResult = await fs.stat(dir);
+        if (!statResult.isDirectory()) {
+          break;
+        }
+      } catch {
+        break;
+      }
+
+      // list directory files for the version
+      const verDirReader = await fs.opendir(dir);
+      let controllerFile: Dirent | null = null;
+      while ((controllerFile = await verDirReader.read()) !== null) {
+        // skip non-files
+        if (!controllerFile.isFile()) {
+          continue;
+        }
+        for (const ext of LOADABLE_EXTENSIONS) {
+          // find the correct extension for the file
+          if (!controllerFile.name.endsWith(ext)) {
+            continue;
+          }
+          // add to list
+          currentEndpoints.set(
+            controllerFile.name.substring(
+              0,
+              controllerFile.name.length - ext.length,
+            ),
+            version,
+          );
+          break;
+        }
+      }
+      await verDirReader.close();
+
+      // configure
+      const configureVersion = await BaseController.configureByNames(
+        currentEndpoints
+          .entries()
+          .map(([name, ver]) => `v${ver}/${name}`)
+          .toArray(),
+      );
+      router
+        .group(configureVersion)
+        .prefix(`/api/v${version}`)
+        .as(`v${version}`);
+    }
+  }
+}

--- a/app/controllers/v1/about_us.ts
+++ b/app/controllers/v1/about_us.ts
@@ -1,11 +1,12 @@
 import router from "@adonisjs/core/services/router";
 import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
 
+import BaseController from "#controllers/base_controller";
 import { aboutUsLinkTypeOrder, compareLinkTypes } from "#enums/link_type";
 import AboutUsGeneral from "#models/about_us_general";
 import AboutUsGeneralLink from "#models/about_us_general_link";
 
-export default class AboutUsController {
+export default class AboutUsController extends BaseController {
   $configureRoutes(controller: LazyImport<Constructor<AboutUsController>>) {
     router.get("/", [controller, "show"]).as("show");
   }

--- a/app/controllers/v1/about_us_links.ts
+++ b/app/controllers/v1/about_us_links.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import AboutUsGeneralLink from "#models/about_us_general_link";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class AboutUsLinksController extends BaseController<
+export default class AboutUsLinksController extends AutoCrudController<
   typeof AboutUsGeneralLink
 > {
   protected readonly queryRelations = [];

--- a/app/controllers/v1/academic_calendars.ts
+++ b/app/controllers/v1/academic_calendars.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import AcademicCalendar from "#models/academic_calendar";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class AcademicCalendarsController extends BaseController<
+export default class AcademicCalendarsController extends AutoCrudController<
   typeof AcademicCalendar
 > {
   protected readonly queryRelations = ["holidays", "daySwaps"];

--- a/app/controllers/v1/aeds.ts
+++ b/app/controllers/v1/aeds.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Aed from "#models/aed";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class AedsController extends BaseController<typeof Aed> {
+export default class AedsController extends AutoCrudController<typeof Aed> {
   protected readonly queryRelations = ["building", "photo"];
   protected readonly crudRelations = [];
   protected readonly model = Aed;

--- a/app/controllers/v1/auth.ts
+++ b/app/controllers/v1/auth.ts
@@ -8,6 +8,7 @@ import router from "@adonisjs/core/services/router";
 import { Constructor, LazyImport } from "@adonisjs/core/types/http";
 
 import { JWT_GUARD, JwtTokenResponse } from "#app/auth/guards/jwt";
+import BaseController from "#controllers/base_controller";
 import {
   ForbiddenException,
   InternalServerException,
@@ -31,7 +32,7 @@ const allAccountsParamSchema = vine.object({
   all: vine.boolean().optional(),
 });
 
-export default class AuthController {
+export default class AuthController extends BaseController {
   $configureRoutes(controller: LazyImport<Constructor<AuthController>>) {
     router
       .group(() => {

--- a/app/controllers/v1/banners.ts
+++ b/app/controllers/v1/banners.ts
@@ -4,14 +4,14 @@ import type {
   CreateHookContext,
   HookContext,
   PartialModel,
-} from "#controllers/base_controller";
+} from "#controllers/auto_crud_controller";
+import AutoCrudController from "#controllers/auto_crud_controller";
 import { BadRequestException } from "#exceptions/http_exceptions";
 import Banner from "#models/banner";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class BannerController extends BaseController<typeof Banner> {
+export default class BannerController extends AutoCrudController<
+  typeof Banner
+> {
   protected readonly queryRelations = [];
   protected readonly crudRelations = [];
   protected readonly model = Banner;

--- a/app/controllers/v1/bicycle_showers.ts
+++ b/app/controllers/v1/bicycle_showers.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import BicycleShower from "#models/bicycle_shower";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class BicycleShowersController extends BaseController<
+export default class BicycleShowersController extends AutoCrudController<
   typeof BicycleShower
 > {
   protected readonly queryRelations = ["building", "photo"];

--- a/app/controllers/v1/buildings.ts
+++ b/app/controllers/v1/buildings.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Building from "#models/building";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class BuildingsController extends BaseController<
+export default class BuildingsController extends AutoCrudController<
   typeof Building
 > {
   protected readonly queryRelations = [

--- a/app/controllers/v1/campuses.ts
+++ b/app/controllers/v1/campuses.ts
@@ -1,9 +1,9 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Campus from "#models/campus";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class CampusesController extends BaseController<typeof Campus> {
+export default class CampusesController extends AutoCrudController<
+  typeof Campus
+> {
   protected readonly queryRelations = [
     "buildings",
     "buildings.cover",

--- a/app/controllers/v1/change_screenshots.ts
+++ b/app/controllers/v1/change_screenshots.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import ChangeScreenshot from "#models/change_screenshot";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class ChangeScreenshotsController extends BaseController<
+export default class ChangeScreenshotsController extends AutoCrudController<
   typeof ChangeScreenshot
 > {
   protected readonly queryRelations = ["image", "change", "change.version"];

--- a/app/controllers/v1/changes.ts
+++ b/app/controllers/v1/changes.ts
@@ -1,9 +1,9 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Change from "#models/change";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class ChangesController extends BaseController<typeof Change> {
+export default class ChangesController extends AutoCrudController<
+  typeof Change
+> {
   protected readonly queryRelations = [
     "version",
     "screenshots",

--- a/app/controllers/v1/contributor_social_links.ts
+++ b/app/controllers/v1/contributor_social_links.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import ContributorSocialLink from "#models/contributor_social_link";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class ContributorSocialLinksController extends BaseController<
+export default class ContributorSocialLinksController extends AutoCrudController<
   typeof ContributorSocialLink
 > {
   protected readonly queryRelations = ["contributor"];

--- a/app/controllers/v1/contributors.ts
+++ b/app/controllers/v1/contributors.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Contributor from "#models/contributor";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class ContributorsController extends BaseController<
+export default class ContributorsController extends AutoCrudController<
   typeof Contributor
 > {
   protected readonly queryRelations = [

--- a/app/controllers/v1/das.ts
+++ b/app/controllers/v1/das.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Das from "#models/das";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class DasController extends BaseController<typeof Das> {
+export default class DasController extends AutoCrudController<typeof Das> {
   protected readonly queryRelations = [
     "maps",
     "maps.content",

--- a/app/controllers/v1/das_links.ts
+++ b/app/controllers/v1/das_links.ts
@@ -1,9 +1,9 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import DasLink from "#models/das_link";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class DasLinkController extends BaseController<typeof DasLink> {
+export default class DasLinkController extends AutoCrudController<
+  typeof DasLink
+> {
   protected readonly queryRelations = ["das"];
   protected readonly crudRelations = [];
   protected readonly model = DasLink;

--- a/app/controllers/v1/das_maps.ts
+++ b/app/controllers/v1/das_maps.ts
@@ -1,9 +1,9 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import DasMap from "#models/das_map";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class DasMapsController extends BaseController<typeof DasMap> {
+export default class DasMapsController extends AutoCrudController<
+  typeof DasMap
+> {
   protected readonly queryRelations = ["das", "content"];
   protected readonly crudRelations = [];
   protected readonly model = DasMap;

--- a/app/controllers/v1/das_stands.ts
+++ b/app/controllers/v1/das_stands.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import DasStand from "#models/das_stand";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class DasStandsController extends BaseController<
+export default class DasStandsController extends AutoCrudController<
   typeof DasStand
 > {
   protected readonly queryRelations = ["das", "logo"];

--- a/app/controllers/v1/das_timetable_entries.ts
+++ b/app/controllers/v1/das_timetable_entries.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import DasTimetableEntry from "#models/das_timetable_entry";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class DasTimetableEntriesController extends BaseController<
+export default class DasTimetableEntriesController extends AutoCrudController<
   typeof DasTimetableEntry
 > {
   protected readonly queryRelations = ["timetable"];

--- a/app/controllers/v1/das_timetables.ts
+++ b/app/controllers/v1/das_timetables.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import DasTimetable from "#models/das_timetable";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class DasTimetableController extends BaseController<
+export default class DasTimetableController extends AutoCrudController<
   typeof DasTimetable
 > {
   protected readonly queryRelations = ["das", "entries"];

--- a/app/controllers/v1/day_swaps.ts
+++ b/app/controllers/v1/day_swaps.ts
@@ -1,9 +1,9 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import DaySwap from "#models/day_swap";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class DaySwapsController extends BaseController<typeof DaySwap> {
+export default class DaySwapsController extends AutoCrudController<
+  typeof DaySwap
+> {
   protected readonly queryRelations = ["academicCalendar"];
   protected readonly crudRelations = [];
   protected readonly model = DaySwap;

--- a/app/controllers/v1/department_links.ts
+++ b/app/controllers/v1/department_links.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import DepartmentLink from "#models/department_link";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class DepartmentLinksController extends BaseController<
+export default class DepartmentLinksController extends AutoCrudController<
   typeof DepartmentLink
 > {
   protected readonly queryRelations = ["department"];

--- a/app/controllers/v1/departments.ts
+++ b/app/controllers/v1/departments.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Department from "#models/department";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class DepartmentsController extends BaseController<
+export default class DepartmentsController extends AutoCrudController<
   typeof Department
 > {
   protected readonly queryRelations = [

--- a/app/controllers/v1/drafts.ts
+++ b/app/controllers/v1/drafts.ts
@@ -17,16 +17,15 @@ import {
   getMorphMapAlias,
   thinModel,
 } from "#app/utils/permissions";
-import { ForbiddenException } from "#exceptions/http_exceptions";
-import GuideArticleDraft from "#models/guide_article_draft";
-import StudentOrganizationDraft from "#models/student_organization_draft";
-
-import BaseController from "../base_controller.js";
+import AutoCrudController from "#controllers/auto_crud_controller";
 import type {
   ControllerAction,
   HookContext,
   Scopes,
-} from "../base_controller.js";
+} from "#controllers/auto_crud_controller";
+import { ForbiddenException } from "#exceptions/http_exceptions";
+import GuideArticleDraft from "#models/guide_article_draft";
+import StudentOrganizationDraft from "#models/student_organization_draft";
 
 type ResourceType = "organization_draft" | "article_draft";
 
@@ -166,7 +165,7 @@ export abstract class GenericDraftController<
   DraftInstance extends ModelAttributes<InstanceType<Draft>> &
     ApprovedInstance &
     BaseDraft,
-> extends BaseController<Draft> {
+> extends AutoCrudController<Draft> {
   // protected readonly queryRelations = ["image", "original", "createdBy"];
   protected readonly crudRelations: string[] = [];
   protected abstract readonly model: Draft;
@@ -225,7 +224,7 @@ export abstract class GenericDraftController<
     action: ControllerAction,
     ids: { localId: number },
   ) {
-    // BaseController's authenticate() should've ensured the user is logged in
+    // AutoCrudController's authenticate() should've ensured the user is logged in
     assert(http.auth.user !== undefined);
     const user = http.auth.user;
 
@@ -313,7 +312,7 @@ export abstract class GenericDraftController<
         `You are not allowed to suggest edits to ${this.approvedModel.name} with id ${originalId}`,
       );
     }
-  } as unknown as BaseController<Draft>["storeHook"];
+  } as unknown as AutoCrudController<Draft>["storeHook"];
 
   protected async postStoreHook(ctx: HookContext<Draft>): Promise<void> {
     // authenticate() should've authenticated the user already

--- a/app/controllers/v1/drafts.ts
+++ b/app/controllers/v1/drafts.ts
@@ -61,9 +61,7 @@ export default class DraftsController extends BaseController {
     assert(user !== undefined);
 
     // Admin roles bypass
-    const hasSolvroAdminRole = (await user.hasRole("solvro_admin")) === true;
-    const hasAdminRole = (await user.hasRole("admin")) === true;
-    if (hasSolvroAdminRole || hasAdminRole) {
+    if (await this.isSuperUser(auth)) {
       return true;
     }
 

--- a/app/controllers/v1/drafts.ts
+++ b/app/controllers/v1/drafts.ts
@@ -23,6 +23,7 @@ import type {
   HookContext,
   Scopes,
 } from "#controllers/auto_crud_controller";
+import BaseController from "#controllers/base_controller";
 import { ForbiddenException } from "#exceptions/http_exceptions";
 import GuideArticleDraft from "#models/guide_article_draft";
 import StudentOrganizationDraft from "#models/student_organization_draft";
@@ -40,7 +41,7 @@ const listDraftsValidator = vine.compile(
   }),
 );
 
-export default class DraftsController {
+export default class DraftsController extends BaseController {
   $configureRoutes(controller: LazyImport<Constructor<DraftsController>>) {
     router.get("/", [controller, "index"]).as("index");
   }

--- a/app/controllers/v1/event_calendar.ts
+++ b/app/controllers/v1/event_calendar.ts
@@ -6,13 +6,13 @@ import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
 import db from "@adonisjs/lucid/services/db";
 import type { ModelAttributes } from "@adonisjs/lucid/types/model";
 
-import BaseController from "#controllers/base_controller";
+import AutoCrudController from "#controllers/auto_crud_controller";
 import type {
   CreateHookContext,
   DeleteHookContext,
   HookContext,
   PartialModel,
-} from "#controllers/base_controller";
+} from "#controllers/auto_crud_controller";
 import {
   BadRequestException,
   ConflictException,
@@ -34,7 +34,7 @@ const showHiddenValidator = vine.compile(
   }),
 );
 
-export default class EventCalendarController extends BaseController<
+export default class EventCalendarController extends AutoCrudController<
   typeof CalendarEvent
 > {
   protected readonly queryRelations = [];
@@ -42,7 +42,9 @@ export default class EventCalendarController extends BaseController<
   protected readonly model = CalendarEvent;
 
   $configureRoutes(
-    controller: LazyImport<Constructor<BaseController<typeof CalendarEvent>>>,
+    controller: LazyImport<
+      Constructor<AutoCrudController<typeof CalendarEvent>>
+    >,
   ) {
     super.$configureRoutes(controller);
     router

--- a/app/controllers/v1/fields_of_study.ts
+++ b/app/controllers/v1/fields_of_study.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import FieldsOfStudy from "#models/field_of_study";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class FieldsOfStudyController extends BaseController<
+export default class FieldsOfStudyController extends AutoCrudController<
   typeof FieldsOfStudy
 > {
   protected readonly queryRelations = ["department"];

--- a/app/controllers/v1/files.ts
+++ b/app/controllers/v1/files.ts
@@ -48,8 +48,7 @@ export default class FilesController extends BaseController {
 
     const user = auth.user;
     assert(user !== undefined);
-    const isAdmin = await user.hasRole("solvro_admin");
-    if (!isAdmin) {
+    if (!(await this.isSuperUser(auth))) {
       try {
         await uploadLimiter.limiter.consume(`upload_user_${user.id}`);
       } catch (e) {

--- a/app/controllers/v1/files.ts
+++ b/app/controllers/v1/files.ts
@@ -7,6 +7,7 @@ import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
 import drive from "@adonisjs/drive/services/main";
 import { errors as limiterErrors } from "@adonisjs/limiter";
 
+import BaseController from "#controllers/base_controller";
 import {
   BadRequestException,
   TooManyRequestsException,
@@ -34,7 +35,7 @@ const directUploadValidator = vine.compile(
   }),
 );
 
-export default class FilesController {
+export default class FilesController extends BaseController {
   $configureRoutes(controller: LazyImport<Constructor<FilesController>>) {
     router.get("/:key", [controller, "get"]).as("show");
     router.post("/", [controller, "post"]).as("upload").use(middleware.auth());

--- a/app/controllers/v1/firebase.ts
+++ b/app/controllers/v1/firebase.ts
@@ -10,13 +10,13 @@ import type {
   HookContext,
   PartialModel,
   RouteConfigurationOptions,
-} from "#controllers/base_controller";
+} from "#controllers/auto_crud_controller";
 import { BadRequestException } from "#exceptions/http_exceptions";
 import FirebaseTopic from "#models/firebase_topic";
 import PushNotificationService from "#services/push_notification_service";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
+const { default: AutoCrudController } = await (() =>
+  import("#controllers/auto_crud_controller"))();
 
 const topicStateParamSchema = vine.object({
   deactivatedSince: vine.luxonDateTime().before(DateTime.now()),
@@ -33,7 +33,7 @@ const pushDataValidator = vine.compile(
   }),
 );
 
-export default class FirebaseController extends BaseController<
+export default class FirebaseController extends AutoCrudController<
   typeof FirebaseTopic
 > {
   $configureRoutes(

--- a/app/controllers/v1/food_spots.ts
+++ b/app/controllers/v1/food_spots.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import FoodSpot from "#models/food_spot";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class FoodSpotsController extends BaseController<
+export default class FoodSpotsController extends AutoCrudController<
   typeof FoodSpot
 > {
   protected readonly queryRelations = ["building", "photo"];

--- a/app/controllers/v1/guide_articles.ts
+++ b/app/controllers/v1/guide_articles.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import GuideArticle from "#models/guide_article";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class GuideArticlesController extends BaseController<
+export default class GuideArticlesController extends AutoCrudController<
   typeof GuideArticle
 > {
   protected readonly queryRelations = [

--- a/app/controllers/v1/guide_authors.ts
+++ b/app/controllers/v1/guide_authors.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import GuideAuthor from "#models/guide_author";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class GuideAuthorsController extends BaseController<
+export default class GuideAuthorsController extends AutoCrudController<
   typeof GuideAuthor
 > {
   protected readonly queryRelations = ["guideArticles"];

--- a/app/controllers/v1/guide_questions.ts
+++ b/app/controllers/v1/guide_questions.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import GuideQuestion from "#models/guide_question";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class GuideQuestionsController extends BaseController<
+export default class GuideQuestionsController extends AutoCrudController<
   typeof GuideQuestion
 > {
   protected readonly queryRelations = ["guideArticle"];

--- a/app/controllers/v1/holidays.ts
+++ b/app/controllers/v1/holidays.ts
@@ -1,9 +1,9 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Holiday from "#models/holiday";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class HolidaysController extends BaseController<typeof Holiday> {
+export default class HolidaysController extends AutoCrudController<
+  typeof Holiday
+> {
   protected readonly queryRelations = ["academicCalendar"];
   protected readonly crudRelations = [];
   protected readonly model = Holiday;

--- a/app/controllers/v1/libraries.ts
+++ b/app/controllers/v1/libraries.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Library from "#models/library";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class LibrariesController extends BaseController<
+export default class LibrariesController extends AutoCrudController<
   typeof Library
 > {
   protected readonly queryRelations = [

--- a/app/controllers/v1/milestones.ts
+++ b/app/controllers/v1/milestones.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Milestone from "#models/milestone";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class MilestonesController extends BaseController<
+export default class MilestonesController extends AutoCrudController<
   typeof Milestone
 > {
   protected readonly queryRelations = [

--- a/app/controllers/v1/mobile_config.ts
+++ b/app/controllers/v1/mobile_config.ts
@@ -2,10 +2,10 @@ import type { HttpContext } from "@adonisjs/core/http";
 import router from "@adonisjs/core/services/router";
 import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
 
-import BaseController from "#controllers/base_controller";
+import AutoCrudController from "#controllers/auto_crud_controller";
 import MobileConfig from "#models/mobile_config";
 
-export default class MobileConfigController extends BaseController<
+export default class MobileConfigController extends AutoCrudController<
   typeof MobileConfig
 > {
   protected queryRelations: string[] = [];
@@ -14,7 +14,9 @@ export default class MobileConfigController extends BaseController<
   protected singletonId = 1;
 
   $configureRoutes(
-    controller: LazyImport<Constructor<BaseController<typeof MobileConfig>>>,
+    controller: LazyImport<
+      Constructor<AutoCrudController<typeof MobileConfig>>
+    >,
   ) {
     super.$configureRoutes(controller);
     router

--- a/app/controllers/v1/newsfeed.ts
+++ b/app/controllers/v1/newsfeed.ts
@@ -4,6 +4,7 @@ import type { HttpContext } from "@adonisjs/core/http";
 import router from "@adonisjs/core/services/router";
 import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
 
+import BaseController from "#controllers/base_controller";
 import { ServiceUnavailableException } from "#exceptions/http_exceptions";
 import NewsfeedService, {
   NEWSFEED_LANGAUGES,
@@ -16,7 +17,7 @@ const validator = vine.compile(
   }),
 );
 
-export default class NewsfeedController {
+export default class NewsfeedController extends BaseController {
   $configureRoutes(controller: LazyImport<Constructor<NewsfeedController>>) {
     router.get("/latest", [controller, "latest"]).as("latest");
     router.get("/stats", [controller, "stats"]).as("stats");

--- a/app/controllers/v1/notification.ts
+++ b/app/controllers/v1/notification.ts
@@ -4,12 +4,10 @@ import type { HttpContext } from "@adonisjs/core/http";
 import router from "@adonisjs/core/services/router";
 import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
 
-import type { RouteConfigurationOptions } from "#controllers/base_controller";
+import type { RouteConfigurationOptions } from "#controllers/auto_crud_controller";
+import AutoCrudController from "#controllers/auto_crud_controller";
 import { BadRequestException } from "#exceptions/http_exceptions";
 import PushNotificationEntry from "#models/push_notification_entry";
-
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
 
 // I give up on using built-in vine functions. Optional and transform cannot be used on union types for some reason.
 const queryParamSchema = vine
@@ -34,7 +32,7 @@ const topicBelongingValidator = vine.object({
   exclude: queryParamSchema,
 });
 
-export default class NotificationController extends BaseController<
+export default class NotificationController extends AutoCrudController<
   typeof PushNotificationEntry
 > {
   $configureRoutes(

--- a/app/controllers/v1/permissions.ts
+++ b/app/controllers/v1/permissions.ts
@@ -59,18 +59,8 @@ export default class PermissionsController extends BaseController {
     router.get("/list", [controller, "listUserPermissions"]).as("list");
   }
 
-  private async ensureSolvroAdmin(auth: HttpContext["auth"]) {
-    if (!auth.isAuthenticated) {
-      await auth.authenticate();
-    }
-    const isAdmin = await auth.user?.hasRole("solvro_admin");
-    if (isAdmin !== true) {
-      throw new ForbiddenException();
-    }
-  }
-
   async allow({ request, auth }: HttpContext) {
-    await this.ensureSolvroAdmin(auth);
+    await this.requireSuperUser(auth);
 
     // Use vine validator
     const { userId, action, modelName, instanceId } =
@@ -101,7 +91,7 @@ export default class PermissionsController extends BaseController {
   }
 
   async revoke({ request, auth }: HttpContext) {
-    await this.ensureSolvroAdmin(auth);
+    await this.requireSuperUser(auth);
 
     // Use vine validator
     const { userId, action, modelName, instanceId } =
@@ -136,7 +126,7 @@ export default class PermissionsController extends BaseController {
    * List all permissions for a specific user
    */
   async listUserPermissions({ request, auth }: HttpContext) {
-    await this.ensureSolvroAdmin(auth);
+    await this.requireSuperUser(auth);
 
     const { userId } = await request.validateUsing(listPermissionsValidator);
 

--- a/app/controllers/v1/permissions.ts
+++ b/app/controllers/v1/permissions.ts
@@ -5,7 +5,7 @@ import type { HttpContext } from "@adonisjs/core/http";
 import router from "@adonisjs/core/services/router";
 import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
 
-import { ForbiddenException } from "#exceptions/http_exceptions";
+import BaseController from "#controllers/base_controller";
 import GuideArticle from "#models/guide_article";
 import GuideArticleDraft from "#models/guide_article_draft";
 import StudentOrganization from "#models/student_organization";
@@ -52,7 +52,7 @@ const listPermissionsValidator = vine.compile(
   }),
 );
 
-export default class PermissionsController {
+export default class PermissionsController extends BaseController {
   $configureRoutes(controller: LazyImport<Constructor<PermissionsController>>) {
     router.post("/allow", [controller, "allow"]).as("allow");
     router.post("/revoke", [controller, "revoke"]).as("revoke");

--- a/app/controllers/v1/pink_boxes.ts
+++ b/app/controllers/v1/pink_boxes.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import PinkBox from "#models/pink_box";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class PinkBoxesController extends BaseController<
+export default class PinkBoxesController extends AutoCrudController<
   typeof PinkBox
 > {
   protected readonly queryRelations = ["building", "photo"];

--- a/app/controllers/v1/polinka_stations.ts
+++ b/app/controllers/v1/polinka_stations.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Polinka from "#models/polinka_station";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class PolinkaStationsController extends BaseController<
+export default class PolinkaStationsController extends AutoCrudController<
   typeof Polinka
 > {
   protected readonly queryRelations = ["photo", "campus"];

--- a/app/controllers/v1/regular_hours.ts
+++ b/app/controllers/v1/regular_hours.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import RegularHour from "#models/regular_hour";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class RegularHoursController extends BaseController<
+export default class RegularHoursController extends AutoCrudController<
   typeof RegularHour
 > {
   protected readonly queryRelations = ["library"];

--- a/app/controllers/v1/roles.ts
+++ b/app/controllers/v1/roles.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Role from "#models/role";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class RolesController extends BaseController<typeof Role> {
+export default class RolesController extends AutoCrudController<typeof Role> {
   protected readonly queryRelations = [
     "contributors",
     "contributors.socialLinks",

--- a/app/controllers/v1/sks_opening_hours.ts
+++ b/app/controllers/v1/sks_opening_hours.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import SksOpeningHours from "#models/sks_opening_hours";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class SksOpeningHoursController extends BaseController<
+export default class SksOpeningHoursController extends AutoCrudController<
   typeof SksOpeningHours
 > {
   protected readonly queryRelations = [];

--- a/app/controllers/v1/special_hours.ts
+++ b/app/controllers/v1/special_hours.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import SpecialHour from "#models/special_hour";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class SpecialHoursController extends BaseController<
+export default class SpecialHoursController extends AutoCrudController<
   typeof SpecialHour
 > {
   protected readonly queryRelations = ["library"];

--- a/app/controllers/v1/student_organization_links.ts
+++ b/app/controllers/v1/student_organization_links.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import StudentOrganizationLink from "#models/student_organization_link";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class StudentOrganizationLinksController extends BaseController<
+export default class StudentOrganizationLinksController extends AutoCrudController<
   typeof StudentOrganizationLink
 > {
   protected readonly queryRelations = ["organization"];

--- a/app/controllers/v1/student_organization_tags.ts
+++ b/app/controllers/v1/student_organization_tags.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import StudentOrganizationTag from "#models/student_organization_tag";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class StudentOrganizationTagsController extends BaseController<
+export default class StudentOrganizationTagsController extends AutoCrudController<
   typeof StudentOrganizationTag
 > {
   protected readonly queryRelations = ["organizations"];

--- a/app/controllers/v1/student_organizations.ts
+++ b/app/controllers/v1/student_organizations.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import StudentOrganization from "#models/student_organization";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class StudentOrganizationsController extends BaseController<
+export default class StudentOrganizationsController extends AutoCrudController<
   typeof StudentOrganization
 > {
   protected readonly queryRelations = [

--- a/app/controllers/v1/version_screenshots.ts
+++ b/app/controllers/v1/version_screenshots.ts
@@ -1,9 +1,7 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import VersionScreenshot from "#models/version_screenshot";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class VersionScreenshotsController extends BaseController<
+export default class VersionScreenshotsController extends AutoCrudController<
   typeof VersionScreenshot
 > {
   protected readonly queryRelations = ["image", "version"];

--- a/app/controllers/v1/versions.ts
+++ b/app/controllers/v1/versions.ts
@@ -1,9 +1,9 @@
+import AutoCrudController from "#controllers/auto_crud_controller";
 import Version from "#models/version";
 
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
-
-export default class VersionsController extends BaseController<typeof Version> {
+export default class VersionsController extends AutoCrudController<
+  typeof Version
+> {
   protected readonly queryRelations = [
     "screenshots",
     "screenshots.image",

--- a/app/controllers/v2/about_us.ts
+++ b/app/controllers/v2/about_us.ts
@@ -1,7 +1,7 @@
-import BaseController from "#controllers/base_controller";
+import AutoCrudController from "#controllers/auto_crud_controller";
 import AboutUsGeneral from "#models/about_us_general";
 
-export default class AboutUsController extends BaseController<
+export default class AboutUsController extends AutoCrudController<
   typeof AboutUsGeneral
 > {
   protected queryRelations = ["coverPhoto"];

--- a/app/models/das_stand.ts
+++ b/app/models/das_stand.ts
@@ -20,7 +20,7 @@ export default class DasStand extends BaseModel {
   @typedColumn({ type: "string", validator: vine.string().maxLength(7) })
   declare number: string; // Knowing PWr, stand number could not be a number
 
-  @typedColumn({ isPrimary: true, foreignKeyOf: () => Das })
+  @typedColumn({ foreignKeyOf: () => Das })
   declare dasId: number;
 
   @belongsTo(() => Das, {
@@ -46,7 +46,6 @@ export default class DasStand extends BaseModel {
   declare description: string | null;
 
   @typedColumn({
-    isPrimary: true,
     foreignKeyOf: () => StudentOrganization,
     optional: true,
   })

--- a/app/utils/controllers.ts
+++ b/app/utils/controllers.ts
@@ -1,0 +1,189 @@
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+
+import router from "@adonisjs/core/services/router";
+import type { Constructor, LazyImport } from "@adonisjs/core/types/http";
+
+import BaseController from "#controllers/base_controller";
+
+export interface ControllerListing {
+  apiVersion: number;
+  controllers: Set<string>;
+}
+
+export interface ImportedController {
+  name: string;
+  apiVersion: number;
+  lazyImport: LazyImport<Constructor<BaseController>>;
+  constructor: Constructor<BaseController>;
+  instance: BaseController;
+  configureRoutes: () => void;
+}
+
+export interface ImportedApiVersion {
+  apiVersion: number;
+  // name to imported
+  controllers: Map<string, ImportedController>;
+}
+
+const LOADABLE_EXTENSIONS = [".js", ".ts"];
+
+/**
+ * Returns a lazy import from the controller directory
+ *
+ * @param apiVersion version of the controller to import (need exact)
+ * @param controllerName name of the controller to import
+ */
+export function lazyImportController(
+  apiVersion: number,
+  controllerName: string,
+): LazyImport<Constructor<unknown>> {
+  return (async () =>
+    import(`#controllers/v${apiVersion}/${controllerName}`)) as LazyImport<
+    Constructor<unknown>
+  >;
+}
+
+/**
+ * Finds all controllers across all versions
+ * Does not do inheritance of controllers between versions
+ */
+export async function listAllControllers(): Promise<ControllerListing[]> {
+  // find all version directories
+  let version = 0;
+  const result: ControllerListing[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    // iterate while directories for each version exist
+    const dir = `./app/controllers/v${++version}`;
+    try {
+      const statResult = await fs.stat(dir);
+      if (!statResult.isDirectory()) {
+        break;
+      }
+    } catch {
+      break;
+    }
+
+    const controllers = new Set<string>();
+
+    // list directory files for the version
+    const verDirReader = await fs.opendir(dir);
+    let controllerFile: Dirent | null = null;
+    while ((controllerFile = await verDirReader.read()) !== null) {
+      // skip non-files
+      if (!controllerFile.isFile()) {
+        continue;
+      }
+      for (const ext of LOADABLE_EXTENSIONS) {
+        // find the correct extension for the file
+        if (!controllerFile.name.endsWith(ext)) {
+          continue;
+        }
+        // add to list
+        controllers.add(
+          controllerFile.name.substring(
+            0,
+            controllerFile.name.length - ext.length,
+          ),
+        );
+        break;
+      }
+    }
+    await verDirReader.close();
+
+    result.push({
+      apiVersion: version,
+      controllers,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Imports all controllers across all versions
+ * Does not do inheritance of controllers between versions
+ */
+export async function importAllControllers(): Promise<ImportedApiVersion[]> {
+  const listing = await listAllControllers();
+  const result: ImportedApiVersion[] = [];
+
+  for (const version of listing) {
+    const controllers = new Map<string, ImportedController>();
+
+    for (const controller of version.controllers) {
+      const lazyImport = lazyImportController(version.apiVersion, controller);
+      const imported = await lazyImport();
+      const constructor = imported.default;
+      const instance = new constructor();
+      if (!(instance instanceof BaseController)) {
+        throw new Error(
+          `File app/controllers/v${version.apiVersion}/${controller}.ts doesn't default export a BaseController!`,
+        );
+      }
+
+      controllers.set(controller, {
+        apiVersion: version.apiVersion,
+        name: controller,
+        lazyImport: lazyImport as LazyImport<Constructor<BaseController>>,
+        constructor: constructor as Constructor<BaseController>,
+        instance,
+        configureRoutes: instance.$configureRoutes.bind(
+          instance,
+          lazyImport as LazyImport<Constructor<BaseController>>,
+        ),
+      });
+    }
+
+    result.push({
+      apiVersion: version.apiVersion,
+      controllers,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Applies inheritance to a listing of imported api versions, modifying the list in place
+ */
+export function applyInheritance(listing: ImportedApiVersion[]) {
+  // sort the versions ascending
+  listing.sort((a, b) => a.apiVersion - b.apiVersion);
+  let previousVersion = listing[0];
+
+  // iterate over the listing
+  for (const version of listing) {
+    // iterate over previous versions' controllers
+    for (const [name, controller] of previousVersion.controllers.entries()) {
+      // if missing in new version, add
+      if (!version.controllers.has(name)) {
+        version.controllers.set(name, controller);
+      }
+    }
+    previousVersion = version;
+  }
+}
+
+/**
+ * Configures all controller routes automatically
+ */
+export async function configureAllRoutes(): Promise<void> {
+  const importedListing = await importAllControllers();
+  applyInheritance(importedListing);
+
+  for (const version of importedListing) {
+    router
+      .group(() => {
+        for (const controller of version.controllers.values()) {
+          router
+            .group(controller.configureRoutes)
+            .prefix(`/${controller.name}`)
+            .as(controller.name);
+        }
+      })
+      .prefix(`/api/v${version.apiVersion}`)
+      .as(`v${version.apiVersion}`);
+  }
+}

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -8,10 +8,8 @@
 */
 import router from "@adonisjs/core/services/router";
 
+import { configureAllRoutes } from "#app/utils/controllers";
 import env from "#start/env";
-
-const { default: BaseController } = await (() =>
-  import("#controllers/base_controller"))();
 
 const MetricsMiddleware = () => import("@solvro/solvronis-metrics");
 
@@ -21,4 +19,4 @@ router.get("/", async () => {
 
 router.get("/metrics", [MetricsMiddleware, "emitMetrics"]);
 
-await BaseController.configureAll();
+await configureAllRoutes();

--- a/tests/unit/controller_self_checks.spec.ts
+++ b/tests/unit/controller_self_checks.spec.ts
@@ -1,0 +1,28 @@
+import { test } from "@japa/runner";
+
+import type { LucidModel } from "@adonisjs/lucid/types/model";
+
+import AutoCrudController from "#app/controllers/auto_crud_controller";
+import type { Scopes } from "#app/controllers/auto_crud_controller";
+import { importAllControllers } from "#app/utils/controllers";
+
+const controllerListing = await importAllControllers();
+
+test.group("AutoCrudController self-checks", () => {
+  for (const version of controllerListing) {
+    for (const controller of version.controllers.values()) {
+      if (!(controller.instance instanceof AutoCrudController)) {
+        continue;
+      }
+      test(`v${controller.apiVersion}/${controller.name}`, async () => {
+        const instance = controller.instance as AutoCrudController<
+          LucidModel & Scopes<LucidModel>
+        >;
+        const result = await instance.doSelfValidate();
+        if (result !== null) {
+          throw new Error(result.messages?.map((x) => x.message).join("\n"));
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
this pr:
- splits the BaseController into two:
  - the current "BaseContoller" was renamed to AutoCrudController
  - the self-routing method and superuser check helpers were moved to the new BaseController
    -  all controllers must now extend this BaseController
- route setup & controller import functions were moved to `utils/controllers.ts`
- each AutoCrudController now gets an autogenerated unit test that calls its self-validate method