### PR TITLE
fix(das): make timetable entry end time nullable

### DIFF
--- a/app/models/das_timetable_entry.ts
+++ b/app/models/das_timetable_entry.ts
@@ -24,9 +24,9 @@ export default class DasTimetableEntry extends BaseModel {
   declare startTime: DateTime;
 
   @typedColumn.dateTime({
-    validator: vine.luxonDateTime().afterField("startsAt"),
+    validator: vine.luxonDateTime().afterField("startTime").optional(),
   })
-  declare endTime: DateTime;
+  declare endTime: DateTime | null;
 
   @typedColumn.dateTime({ autoCreate: true })
   declare createdAt: DateTime;


### PR DESCRIPTION
#293

Make DasTimetableEntry.endTime nullable and update validation so null values are allowed for timetable entries that only have a start time.

Fix validator also and avoid errors when the end time is not known.