### PR TITLE
fix(das): make timetable entry end time nullable

### DIFF
--- a/app/models/das_timetable_entry.ts
+++ b/app/models/das_timetable_entry.ts
@@ -24,9 +24,9 @@ export default class DasTimetableEntry extends BaseModel {
   declare startTime: DateTime;
 
   @typedColumn.dateTime({
-    validator: vine.luxonDateTime().afterField("startsAt"),
+    validator: vine.luxonDateTime().afterField("startTime").optional(),
   })
-  declare endTime: DateTime;
+  declare endTime: DateTime | null;
 
   @typedColumn.dateTime({ autoCreate: true })
   declare createdAt: DateTime;

--- a/database/migrations/1777556396850_alter_das_timetable_entries_end_time_nullables_table.ts
+++ b/database/migrations/1777556396850_alter_das_timetable_entries_end_time_nullables_table.ts
@@ -5,13 +5,13 @@ export default class extends BaseSchema {
 
   async up() {
     this.schema.alterTable(this.tableName, (table) => {
-      table.timestamp("end_time").nullable().alter();
+      table.setNullable("end_time");
     });
   }
 
   async down() {
     this.schema.alterTable(this.tableName, (table) => {
-      table.timestamp("end_time").notNullable().alter();
+      table.dropNullable("end_time");
     });
   }
 }

--- a/database/migrations/1777556396850_create_alter_das_timetable_entries_end_time_nullables_table.ts
+++ b/database/migrations/1777556396850_create_alter_das_timetable_entries_end_time_nullables_table.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "das_timetable_entries";
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.timestamp("end_time").nullable().alter();
+    });
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.timestamp("end_time").notNullable().alter();
+    });
+  }
+}


### PR DESCRIPTION
#293 
Make DasTimetableEntry.endTime nullable and update validation so null values are allowed for timetable entries that only have a start time.

Fix validator also and avoid errors when the end time is not known.