### PR TITLE
fix(das): specify foreign key for timetable entry

### DIFF
--- a/app/models/das_timetable.ts
+++ b/app/models/das_timetable.ts
@@ -33,7 +33,9 @@ export default class DasTimetable extends BaseModel {
   })
   declare das: BelongsTo<typeof Das>;
 
-  @hasMany(() => DasTimetableEntry)
+  @hasMany(() => DasTimetableEntry, {
+    foreignKey: "timetableId",
+  })
   declare entries: HasMany<typeof DasTimetableEntry>;
 
   static preloadRelations = preloadRelations();


### PR DESCRIPTION
### Summary

Fixes preloading timetable entries through the DAS timetable endpoint.

Lucid inferred the relation foreign key as `dasTimetableId`, while
`DasTimetableEntry` defines it as `timetableId`. This caused requests with the
`entries` relation to fail with `E_MISSING_MODEL_ATTRIBUTE`.

The relation now explicitly uses `timetableId`.

### Before

```http
GET /api/v1/das_timetables/1?entries=true
```
Returned HTTP 500:
Relation "DasTimetable.entries" expects "dasTimetableId" to exist on
"DasTimetableEntry" model, but is missing.

failling prod endpoint: https://api.topwr.solvro.pl/api/v1/das_timetables/1?entries=true 

### After
The same request returns HTTP 200 with the timetable entries preloaded,
including entries with a nullable endTime.