### PR TITLE
refactor: deduplicate unit test support functions (#323)

### DIFF
--- a/tests/functional/auth_helpers.ts
+++ b/tests/functional/auth_helpers.ts
@@ -6,11 +6,9 @@ import db from "@adonisjs/lucid/services/db";
 import User from "#models/user";
 import env from "#start/env";
 
-export function createUniqueEmail(domain: string) {
-  return (prefix: string): string => {
-    const id = crypto.randomUUID().slice(0, 8);
-    return `${prefix}-${id}@${domain}`;
-  };
+export function uniqueEmail(prefix: string): string {
+  const id = crypto.randomUUID().slice(0, 8);
+  return `${prefix}-${id}@example.test`;
 }
 
 export async function makeToken(user: User): Promise<string> {
@@ -95,30 +93,30 @@ export async function assignSolvroAdmin(user: User) {
 }
 
 export async function createUserWithToken(
-  uniqueEmail: (prefix: string) => string,
   prefix: string,
   fullName: string,
-): Promise<{ user: User; token: string }> {
+): Promise<{ user: User; token: string; password: string }> {
+  const password = `Test-${crypto.randomUUID().slice(0, 8)}!`;
   const user = await User.create({
     email: uniqueEmail(prefix),
-    password: "Passw0rd!",
+    password,
     fullName,
   });
   const token = await makeToken(user);
-  return { user, token };
+  return { user, token, password };
 }
 
 export async function createAdminWithToken(
-  uniqueEmail: (prefix: string) => string,
   prefix: string,
   fullName: string,
-): Promise<{ user: User; token: string }> {
+): Promise<{ user: User; token: string; password: string }> {
+  const password = `Test-${crypto.randomUUID().slice(0, 8)}!`;
   const user = await User.create({
     email: uniqueEmail(prefix),
-    password: "Passw0rd!",
+    password,
     fullName,
   });
   await assignSolvroAdmin(user);
   const token = await makeToken(user);
-  return { user, token };
+  return { user, token, password };
 }

--- a/tests/functional/auth_helpers.ts
+++ b/tests/functional/auth_helpers.ts
@@ -7,7 +7,7 @@ import User from "#models/user";
 import env from "#start/env";
 
 export function uniqueEmail(prefix: string): string {
-  const id = crypto.randomUUID().slice(0, 8);
+  const id = crypto.randomBytes(4).toString("hex");
   return `${prefix}-${id}@example.test`;
 }
 
@@ -96,7 +96,7 @@ export async function createUserWithToken(
   prefix: string,
   fullName: string,
 ): Promise<{ user: User; token: string; password: string }> {
-  const password = `Test-${crypto.randomUUID().slice(0, 8)}!`;
+  const password = `Test-${crypto.randomBytes(16).toString("hex")}!`;
   const user = await User.create({
     email: uniqueEmail(prefix),
     password,
@@ -110,7 +110,7 @@ export async function createAdminWithToken(
   prefix: string,
   fullName: string,
 ): Promise<{ user: User; token: string; password: string }> {
-  const password = `Test-${crypto.randomUUID().slice(0, 8)}!`;
+  const password = `Test-${crypto.randomBytes(16).toString("hex")}!`;
   const user = await User.create({
     email: uniqueEmail(prefix),
     password,

--- a/tests/functional/auth_helpers.ts
+++ b/tests/functional/auth_helpers.ts
@@ -1,0 +1,124 @@
+import jwt from "jsonwebtoken";
+import crypto from "node:crypto";
+
+import db from "@adonisjs/lucid/services/db";
+
+import User from "#models/user";
+import env from "#start/env";
+
+export function createUniqueEmail(domain: string) {
+  return (prefix: string): string => {
+    const id = crypto.randomUUID().slice(0, 8);
+    return `${prefix}-${id}@${domain}`;
+  };
+}
+
+export async function makeToken(user: User): Promise<string> {
+  const ACCESS_SECRET = env.get("ACCESS_SECRET");
+  const AUDIENCE = "admin.topwr.solvro.pl";
+  const ISSUER = "admin.topwr.solvro.pl";
+  const ACCESS_EXPIRES_IN_MS = Number.parseInt(
+    env.get("ACCESS_EXPIRES_IN_MS", "3600000"),
+  );
+
+  return jwt.sign(
+    {
+      isRefresh: false,
+    },
+    ACCESS_SECRET,
+    {
+      subject: user.id.toString(),
+      audience: AUDIENCE,
+      issuer: ISSUER,
+      expiresIn: ACCESS_EXPIRES_IN_MS,
+      algorithm: "HS256",
+      allowInsecureKeySizes: false,
+      allowInvalidAsymmetricKeyTypes: false,
+    },
+  );
+}
+
+export async function ensureSolvroAdminRoleId(): Promise<number> {
+  // Ensure 'solvro_admin' exists in access_roles and return its id
+  const existing: unknown = await db
+    .knexQuery()
+    .table("access_roles")
+    .where({ slug: "solvro_admin" })
+    .first();
+  if (existing !== null && existing !== undefined) {
+    return Number((existing as { id: number | string }).id);
+  }
+
+  const idNum = await db
+    .knexQuery()
+    .table("access_roles")
+    .insert({
+      slug: "solvro_admin",
+      created_at: new Date(),
+      updated_at: new Date(),
+    })
+    .returning("id")
+    .then((result: unknown) => {
+      if (Array.isArray(result)) {
+        const first = result[0] as unknown;
+        if (typeof first === "object" && first !== null && "id" in first) {
+          return Number((first as { id: number | string }).id);
+        }
+        return Number(first);
+      }
+      if (typeof result === "object" && result !== null && "id" in result) {
+        return Number((result as { id: number | string }).id);
+      }
+      return Number(result);
+    });
+
+  return idNum;
+}
+
+export async function assignSolvroAdmin(user: User) {
+  const roleId = await ensureSolvroAdminRoleId();
+  // model_roles: model_type, model_id, role_id
+  const existing: unknown = await db
+    .knexQuery()
+    .table("model_roles")
+    .where({ model_type: "users", model_id: user.id, role_id: roleId })
+    .first();
+  if (existing === null || existing === undefined) {
+    await db.knexQuery().table("model_roles").insert({
+      model_type: "users",
+      model_id: user.id,
+      role_id: roleId,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+  }
+}
+
+export async function createUserWithToken(
+  uniqueEmail: (prefix: string) => string,
+  prefix: string,
+  fullName: string,
+): Promise<{ user: User; token: string }> {
+  const user = await User.create({
+    email: uniqueEmail(prefix),
+    password: "Passw0rd!",
+    fullName,
+  });
+  const token = await makeToken(user);
+  return { user, token };
+}
+
+export async function createAdminWithToken(
+  uniqueEmail: (prefix: string) => string,
+  prefix: string,
+  fullName: string,
+): Promise<{ user: User; token: string }> {
+  const user = await User.create({
+    email: uniqueEmail(prefix),
+    password: "Passw0rd!",
+    fullName,
+  });
+  await assignSolvroAdmin(user);
+  const token = await makeToken(user);
+  return { user, token };
+}

--- a/tests/functional/drafts_acl.spec.ts
+++ b/tests/functional/drafts_acl.spec.ts
@@ -12,13 +12,7 @@ import GuideArticleDraft from "#models/guide_article_draft";
 import StudentOrganization from "#models/student_organization";
 import StudentOrganizationDraft from "#models/student_organization_draft";
 
-import {
-  createAdminWithToken,
-  createUniqueEmail,
-  createUserWithToken,
-} from "./auth_helpers.js";
-
-const uniqueEmail = createUniqueEmail("drafts.test");
+import { createAdminWithToken, createUserWithToken } from "./auth_helpers.js";
 
 test.group("Drafts ACL (per-model and class-level)", (group) => {
   group.setup(async () => {
@@ -31,18 +25,8 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: per-model read allows only assigned user", async ({
     client,
   }) => {
-    const { user: u1, token: t1 } = await createUserWithToken(
-      uniqueEmail,
-      "u1",
-      "User 1",
-    );
-    const { user: u2, token: t2 } = await createUserWithToken(
-      uniqueEmail,
-      "u2",
-      "User 2",
-    );
-    await u1.refresh();
-    await u2.refresh();
+    const { user: u1, token: t1 } = await createUserWithToken("u1", "User 1");
+    const { token: t2 } = await createUserWithToken("u2", "User 2");
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft Org A",
@@ -71,13 +55,7 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: class-level read allows any draft", async ({
     client,
   }) => {
-    const { user: user3, token } = await createUserWithToken(
-      uniqueEmail,
-      "user3",
-      "User 3",
-    );
-
-    await user3.refresh();
+    const { user: user3, token } = await createUserWithToken("user3", "User 3");
 
     const d1 = await StudentOrganizationDraft.create({
       name: "Draft Org B",
@@ -117,17 +95,10 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
     client,
   }) => {
     const { user: u1, token: t1 } = await createUserWithToken(
-      uniqueEmail,
       "user4",
       "User 4",
     );
-    const { user: u2, token: t2 } = await createUserWithToken(
-      uniqueEmail,
-      "user5",
-      "User 5",
-    );
-    await u1.refresh();
-    await u2.refresh();
+    const { token: t2 } = await createUserWithToken("user5", "User 5");
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft Org D",
@@ -157,17 +128,10 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
 
   test("guide article draft: per-model read and update", async ({ client }) => {
     const { user: u1, token: t1 } = await createUserWithToken(
-      uniqueEmail,
       "user6",
       "User 6",
     );
-    const { user: u2, token: t2 } = await createUserWithToken(
-      uniqueEmail,
-      "user7",
-      "User 7",
-    );
-    await u1.refresh();
-    await u2.refresh();
+    const { token: t2 } = await createUserWithToken("user7", "User 7");
 
     const { default: FileEntry } = await import("#models/file_entry");
     const file = FileEntry.createNew("png");
@@ -210,13 +174,7 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: store requires class-level create on StudentOrganizationDraft and suggest_new StudentOrganization", async ({
     client,
   }) => {
-    const { user, token } = await createUserWithToken(
-      uniqueEmail,
-      "user8",
-      "User 8",
-    );
-
-    await user.refresh();
+    const { user, token } = await createUserWithToken("user8", "User 8");
 
     // no permission -> 403
     const noPerm = await client
@@ -270,12 +228,10 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
     client,
   }) => {
     const { user: owner, token: tOwner } = await createUserWithToken(
-      uniqueEmail,
       "u14",
       "Owner",
     );
     const { user: other, token: tOther } = await createUserWithToken(
-      uniqueEmail,
       "u15",
       "Other",
     );
@@ -335,12 +291,10 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
     client,
   }) => {
     const { user: owner, token: tOwner } = await createUserWithToken(
-      uniqueEmail,
       "u16",
       "Owner",
     );
     const { user: other, token: tOther } = await createUserWithToken(
-      uniqueEmail,
       "u17",
       "Other",
     );
@@ -393,18 +347,8 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: destroy requires permission; per-model allowed", async ({
     client,
   }) => {
-    const { user: u1, token: t1 } = await createUserWithToken(
-      uniqueEmail,
-      "u9",
-      "User 9",
-    );
-    const { user: u2, token: t2 } = await createUserWithToken(
-      uniqueEmail,
-      "u10",
-      "User 10",
-    );
-    await u1.refresh();
-    await u2.refresh();
+    const { user: u1, token: t1 } = await createUserWithToken("u9", "User 9");
+    const { token: t2 } = await createUserWithToken("u10", "User 10");
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft To Delete",
@@ -434,11 +378,7 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("guide article draft: store requires class-level create on GuideArticleDraft and suggest_new GuideArticle", async ({
     client,
   }) => {
-    const { user, token } = await createUserWithToken(
-      uniqueEmail,
-      "user11",
-      "User",
-    );
+    const { user, token } = await createUserWithToken("user11", "User");
 
     const { default: FileEntry } = await import("#models/file_entry");
     const { default: GuideArticle } = await import("#models/guide_article");
@@ -491,16 +431,8 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("guide article draft: destroy requires per-model", async ({
     client,
   }) => {
-    const { user: u1, token: t1 } = await createUserWithToken(
-      uniqueEmail,
-      "u12",
-      "User 12",
-    );
-    const { token: t2 } = await createUserWithToken(
-      uniqueEmail,
-      "u13",
-      "User 13",
-    );
+    const { user: u1, token: t1 } = await createUserWithToken("u12", "User 12");
+    const { token: t2 } = await createUserWithToken("u13", "User 13");
 
     const { default: FileEntry } = await import("#models/file_entry");
     const file2 = FileEntry.createNew("png");
@@ -532,12 +464,9 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
     assert,
   }) => {
     const { user: adminUser, token: adminToken } = await createAdminWithToken(
-      uniqueEmail,
       "admin1",
       "Admin 1",
     );
-
-    await adminUser.refresh();
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft Org To Approve",
@@ -575,12 +504,9 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
     assert,
   }) => {
     const { user: adminUser, token: adminToken } = await createAdminWithToken(
-      uniqueEmail,
       "admin2",
       "Admin 2",
     );
-
-    await adminUser.refresh();
 
     const existingOrg = await StudentOrganization.create({
       name: "Existing Org",
@@ -623,12 +549,9 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
     client,
   }) => {
     const { user: regularUser, token } = await createUserWithToken(
-      uniqueEmail,
       "regular-approve",
       "Regular User",
     );
-
-    await regularUser.refresh();
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft Org No Approve",

--- a/tests/functional/drafts_acl.spec.ts
+++ b/tests/functional/drafts_acl.spec.ts
@@ -1,11 +1,8 @@
 import { Acl } from "@holoyan/adonisjs-permissions";
-import jwt from "jsonwebtoken";
-import crypto from "node:crypto";
 
 import { test } from "@japa/runner";
 
 import testUtils from "@adonisjs/core/services/test_utils";
-import db from "@adonisjs/lucid/services/db";
 
 import { Branch } from "#enums/branch";
 import { OrganizationSource } from "#enums/organization_source";
@@ -14,105 +11,14 @@ import { OrganizationType } from "#enums/organization_type";
 import GuideArticleDraft from "#models/guide_article_draft";
 import StudentOrganization from "#models/student_organization";
 import StudentOrganizationDraft from "#models/student_organization_draft";
-import User from "#models/user";
-import env from "#start/env";
 
-function uniqueEmail(prefix: string) {
-  const id = crypto.randomUUID().slice(0, 8);
-  return `${prefix}-${id}@drafts.test`;
-}
+import {
+  createAdminWithToken,
+  createUniqueEmail,
+  createUserWithToken,
+} from "./auth_helpers.js";
 
-async function makeToken(user: User): Promise<string> {
-  const ACCESS_SECRET = env.get("ACCESS_SECRET");
-  const AUDIENCE = "admin.topwr.solvro.pl";
-  const ISSUER = "admin.topwr.solvro.pl";
-  const ACCESS_EXPIRES_IN_MS = Number.parseInt(
-    env.get("ACCESS_EXPIRES_IN_MS", "3600000"),
-  );
-
-  return jwt.sign(
-    {
-      isRefresh: false,
-    },
-    ACCESS_SECRET,
-    {
-      subject: user.id.toString(),
-      audience: AUDIENCE,
-      issuer: ISSUER,
-      expiresIn: ACCESS_EXPIRES_IN_MS,
-      algorithm: "HS256",
-      allowInsecureKeySizes: false,
-      allowInvalidAsymmetricKeyTypes: false,
-    },
-  );
-}
-
-async function ensureSolvroAdminRoleId(): Promise<number> {
-  // Ensure 'solvro_admin' exists in access_roles and return its id
-  const roleExists = await db
-    .knexQuery()
-    .table("access_roles")
-    .where({ slug: "solvro_admin" })
-    .first()
-    .then((row: unknown) => row !== null && row !== undefined);
-  if (roleExists) {
-    const roleRow: unknown = await db
-      .knexQuery()
-      .table("access_roles")
-      .where({ slug: "solvro_admin" })
-      .first();
-    // row is present; fetch id using a second query to keep types simple
-    if (typeof roleRow === "object" && roleRow !== null && "id" in roleRow) {
-      return Number((roleRow as { id: number | string }).id);
-    }
-    throw new Error("Invalid roleRow payload");
-  }
-
-  const idNum = await db
-    .knexQuery()
-    .table("access_roles")
-    .insert({
-      slug: "solvro_admin",
-      created_at: new Date(),
-      updated_at: new Date(),
-    })
-    .returning("id")
-    .then((result: unknown) => {
-      if (Array.isArray(result)) {
-        const first = result[0] as unknown;
-        if (typeof first === "object" && first !== null && "id" in first) {
-          return Number((first as { id: number | string }).id);
-        }
-        return Number(first);
-      }
-      if (typeof result === "object" && result !== null && "id" in result) {
-        return Number((result as { id: number | string }).id);
-      }
-      return Number(result);
-    });
-
-  return idNum;
-}
-
-async function assignSolvroAdmin(user: User) {
-  const roleId = await ensureSolvroAdminRoleId();
-  // model_roles: model_type, model_id, role_id
-  const exists = await db
-    .knexQuery()
-    .table("model_roles")
-    .where({ model_type: "users", model_id: user.id, role_id: roleId })
-    .first()
-    .then((row: unknown) => row !== null && row !== undefined);
-  if (!exists) {
-    await db.knexQuery().table("model_roles").insert({
-      model_type: "users",
-      model_id: user.id,
-      role_id: roleId,
-      created_at: new Date(),
-      updated_at: new Date(),
-    });
-  }
-}
+const uniqueEmail = createUniqueEmail("drafts.test");
 
 test.group("Drafts ACL (per-model and class-level)", (group) => {
   group.setup(async () => {
@@ -125,20 +31,18 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: per-model read allows only assigned user", async ({
     client,
   }) => {
-    const u1 = await User.create({
-      email: uniqueEmail("u1"),
-      password: "Passw0rd!",
-      fullName: "User 1",
-    });
-    const u2 = await User.create({
-      email: uniqueEmail("u2"),
-      password: "Passw0rd!",
-      fullName: "User 2",
-    });
+    const { user: u1, token: t1 } = await createUserWithToken(
+      uniqueEmail,
+      "u1",
+      "User 1",
+    );
+    const { user: u2, token: t2 } = await createUserWithToken(
+      uniqueEmail,
+      "u2",
+      "User 2",
+    );
     await u1.refresh();
     await u2.refresh();
-    const t1 = await makeToken(u1);
-    const t2 = await makeToken(u2);
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft Org A",
@@ -167,13 +71,13 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: class-level read allows any draft", async ({
     client,
   }) => {
-    const u = await User.create({
-      email: uniqueEmail("u3"),
-      password: "Passw0rd!",
-      fullName: "User 3",
-    });
-    await u.refresh();
-    const token = await makeToken(u);
+    const { user: user3, token } = await createUserWithToken(
+      uniqueEmail,
+      "user3",
+      "User 3",
+    );
+
+    await user3.refresh();
 
     const d1 = await StudentOrganizationDraft.create({
       name: "Draft Org B",
@@ -183,7 +87,7 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
       organizationType: OrganizationType.StudentOrganization,
       organizationStatus: OrganizationStatus.Active,
       branch: Branch.Main,
-      createdByUserId: u.id,
+      createdByUserId: user3.id,
     });
     const d2 = await StudentOrganizationDraft.create({
       name: "Draft Org C",
@@ -193,10 +97,10 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
       organizationType: OrganizationType.StudentOrganization,
       organizationStatus: OrganizationStatus.Active,
       branch: Branch.Main,
-      createdByUserId: u.id,
+      createdByUserId: user3.id,
     });
 
-    await Acl.model(u).allow("read", StudentOrganizationDraft);
+    await Acl.model(user3).allow("read", StudentOrganizationDraft);
 
     const res1 = await client
       .get(`/api/v1/student_organization_drafts/${d1.id}`)
@@ -212,20 +116,18 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: per-model update only for assigned user", async ({
     client,
   }) => {
-    const u1 = await User.create({
-      email: uniqueEmail("u4"),
-      password: "Passw0rd!",
-      fullName: "User 4",
-    });
-    const u2 = await User.create({
-      email: uniqueEmail("u5"),
-      password: "Passw0rd!",
-      fullName: "User 5",
-    });
+    const { user: u1, token: t1 } = await createUserWithToken(
+      uniqueEmail,
+      "user4",
+      "User 4",
+    );
+    const { user: u2, token: t2 } = await createUserWithToken(
+      uniqueEmail,
+      "user5",
+      "User 5",
+    );
     await u1.refresh();
     await u2.refresh();
-    const t1 = await makeToken(u1);
-    const t2 = await makeToken(u2);
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft Org D",
@@ -254,20 +156,18 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   });
 
   test("guide article draft: per-model read and update", async ({ client }) => {
-    const u1 = await User.create({
-      email: uniqueEmail("u6"),
-      password: "Passw0rd!",
-      fullName: "User 6",
-    });
-    const u2 = await User.create({
-      email: uniqueEmail("u7"),
-      password: "Passw0rd!",
-      fullName: "User 7",
-    });
+    const { user: u1, token: t1 } = await createUserWithToken(
+      uniqueEmail,
+      "user6",
+      "User 6",
+    );
+    const { user: u2, token: t2 } = await createUserWithToken(
+      uniqueEmail,
+      "user7",
+      "User 7",
+    );
     await u1.refresh();
     await u2.refresh();
-    const t1 = await makeToken(u1);
-    const t2 = await makeToken(u2);
 
     const { default: FileEntry } = await import("#models/file_entry");
     const file = FileEntry.createNew("png");
@@ -310,12 +210,13 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: store requires class-level create on StudentOrganizationDraft and suggest_new StudentOrganization", async ({
     client,
   }) => {
-    const user = await User.create({
-      email: uniqueEmail("u8"),
-      password: "Passw0rd!",
-      fullName: "User 8",
-    });
-    const token = await makeToken(user);
+    const { user, token } = await createUserWithToken(
+      uniqueEmail,
+      "user8",
+      "User 8",
+    );
+
+    await user.refresh();
 
     // no permission -> 403
     const noPerm = await client
@@ -368,18 +269,16 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: store with originalId requires per-model suggest_edit on original", async ({
     client,
   }) => {
-    const owner = await User.create({
-      email: uniqueEmail("u14"),
-      password: "Passw0rd!",
-      fullName: "Owner",
-    });
-    const other = await User.create({
-      email: uniqueEmail("u15"),
-      password: "Passw0rd!",
-      fullName: "Other",
-    });
-    const tOwner = await makeToken(owner);
-    const tOther = await makeToken(other);
+    const { user: owner, token: tOwner } = await createUserWithToken(
+      uniqueEmail,
+      "u14",
+      "Owner",
+    );
+    const { user: other, token: tOther } = await createUserWithToken(
+      uniqueEmail,
+      "u15",
+      "Other",
+    );
 
     // create a base entity
     const studentOrgModule = await import("#models/student_organization");
@@ -435,18 +334,16 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("guide article draft: store with originalId requires per-model suggest_edit on original", async ({
     client,
   }) => {
-    const owner = await User.create({
-      email: uniqueEmail("u16"),
-      password: "Passw0rd!",
-      fullName: "Owner 2",
-    });
-    const other = await User.create({
-      email: uniqueEmail("u17"),
-      password: "Passw0rd!",
-      fullName: "Other 2",
-    });
-    const tOwner = await makeToken(owner);
-    const tOther = await makeToken(other);
+    const { user: owner, token: tOwner } = await createUserWithToken(
+      uniqueEmail,
+      "u16",
+      "Owner",
+    );
+    const { user: other, token: tOther } = await createUserWithToken(
+      uniqueEmail,
+      "u17",
+      "Other",
+    );
 
     const { default: FileEntry } = await import("#models/file_entry");
     const file = FileEntry.createNew("png");
@@ -496,20 +393,18 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: destroy requires permission; per-model allowed", async ({
     client,
   }) => {
-    const u1 = await User.create({
-      email: uniqueEmail("u9"),
-      password: "Passw0rd!",
-      fullName: "User 9",
-    });
-    const u2 = await User.create({
-      email: uniqueEmail("u10"),
-      password: "Passw0rd!",
-      fullName: "User 10",
-    });
+    const { user: u1, token: t1 } = await createUserWithToken(
+      uniqueEmail,
+      "u9",
+      "User 9",
+    );
+    const { user: u2, token: t2 } = await createUserWithToken(
+      uniqueEmail,
+      "u10",
+      "User 10",
+    );
     await u1.refresh();
     await u2.refresh();
-    const t1 = await makeToken(u1);
-    const t2 = await makeToken(u2);
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft To Delete",
@@ -539,12 +434,11 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("guide article draft: store requires class-level create on GuideArticleDraft and suggest_new GuideArticle", async ({
     client,
   }) => {
-    const user = await User.create({
-      email: uniqueEmail("u11"),
-      password: "Passw0rd!",
-      fullName: "User 11",
-    });
-    const token = await makeToken(user);
+    const { user, token } = await createUserWithToken(
+      uniqueEmail,
+      "user11",
+      "User",
+    );
 
     const { default: FileEntry } = await import("#models/file_entry");
     const { default: GuideArticle } = await import("#models/guide_article");
@@ -597,18 +491,16 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("guide article draft: destroy requires per-model", async ({
     client,
   }) => {
-    const u1 = await User.create({
-      email: uniqueEmail("u12"),
-      password: "Passw0rd!",
-      fullName: "User 12",
-    });
-    const u2 = await User.create({
-      email: uniqueEmail("u13"),
-      password: "Passw0rd!",
-      fullName: "User 13",
-    });
-    const t1 = await makeToken(u1);
-    const t2 = await makeToken(u2);
+    const { user: u1, token: t1 } = await createUserWithToken(
+      uniqueEmail,
+      "u12",
+      "User 12",
+    );
+    const { token: t2 } = await createUserWithToken(
+      uniqueEmail,
+      "u13",
+      "User 13",
+    );
 
     const { default: FileEntry } = await import("#models/file_entry");
     const file2 = FileEntry.createNew("png");
@@ -639,14 +531,13 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
     client,
     assert,
   }) => {
-    const adminUser = await User.create({
-      email: uniqueEmail("admin-approve"),
-      password: "Passw0rd!",
-      fullName: "Approve Admin",
-    });
-    await assignSolvroAdmin(adminUser);
+    const { user: adminUser, token: adminToken } = await createAdminWithToken(
+      uniqueEmail,
+      "admin1",
+      "Admin 1",
+    );
+
     await adminUser.refresh();
-    const adminToken = await makeToken(adminUser);
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft Org To Approve",
@@ -683,14 +574,13 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
     client,
     assert,
   }) => {
-    const adminUser = await User.create({
-      email: uniqueEmail("admin-approve2"),
-      password: "Passw0rd!",
-      fullName: "Approve Admin 2",
-    });
-    await assignSolvroAdmin(adminUser);
+    const { user: adminUser, token: adminToken } = await createAdminWithToken(
+      uniqueEmail,
+      "admin2",
+      "Admin 2",
+    );
+
     await adminUser.refresh();
-    const adminToken = await makeToken(adminUser);
 
     const existingOrg = await StudentOrganization.create({
       name: "Existing Org",
@@ -732,13 +622,13 @@ test.group("Drafts ACL (per-model and class-level)", (group) => {
   test("student org draft: approve requires solvro_admin", async ({
     client,
   }) => {
-    const regularUser = await User.create({
-      email: uniqueEmail("regular-approve"),
-      password: "Passw0rd!",
-      fullName: "Regular User",
-    });
+    const { user: regularUser, token } = await createUserWithToken(
+      uniqueEmail,
+      "regular-approve",
+      "Regular User",
+    );
+
     await regularUser.refresh();
-    const token = await makeToken(regularUser);
 
     const draft = await StudentOrganizationDraft.create({
       name: "Draft Org No Approve",

--- a/tests/functional/permissions.spec.ts
+++ b/tests/functional/permissions.spec.ts
@@ -10,13 +10,7 @@ import Milestone from "#models/milestone";
 import Role from "#models/role";
 import User from "#models/user";
 
-import {
-  createAdminWithToken,
-  createUniqueEmail,
-  createUserWithToken,
-} from "./auth_helpers.js";
-
-const uniqueEmail = createUniqueEmail("perm.test");
+import { createAdminWithToken, createUserWithToken } from "./auth_helpers.js";
 
 test.group("Permissions", (group) => {
   group.setup(async () => {
@@ -27,7 +21,7 @@ test.group("Permissions", (group) => {
   });
   group.each.teardown(async () => {
     // Light cleanup for test-created users and libraries
-    await User.query().where("email", "like", "%@perm.test").delete();
+    await User.query().where("email", "like", "%@example.test").delete();
     await Library.query().where("title", "like", "PermTest %").delete();
   });
 
@@ -40,11 +34,7 @@ test.group("Permissions", (group) => {
   test("store requires permission: regular user gets 403", async ({
     client,
   }) => {
-    const { token } = await createUserWithToken(
-      uniqueEmail,
-      "user1",
-      "Perm User 1",
-    );
+    const { token } = await createUserWithToken("user1", "Perm User 1");
 
     const res = await client
       .post("/api/v1/libraries")
@@ -55,11 +45,7 @@ test.group("Permissions", (group) => {
   });
 
   test("solvro_admin bypass: can store", async ({ client, assert }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin1",
-      "Solvro Admin",
-    );
+    const { token } = await createAdminWithToken("admin1", "Solvro Admin");
 
     const res = await client
       .post("/api/v1/libraries")
@@ -86,7 +72,6 @@ test.group("Permissions", (group) => {
   }) => {
     // Create a record as solvro_admin
     const { token: adminToken } = await createAdminWithToken(
-      uniqueEmail,
       "admin2",
       "Solvro Admin 2",
     );
@@ -106,7 +91,6 @@ test.group("Permissions", (group) => {
 
     // Regular user cannot update
     const { token: userToken } = await createUserWithToken(
-      uniqueEmail,
       "user2",
       "Perm User 2",
     );
@@ -132,7 +116,6 @@ test.group("Permissions", (group) => {
     assert,
   }) => {
     const { token: adminToken } = await createAdminWithToken(
-      uniqueEmail,
       "admin3",
       "Solvro Admin 3",
     );
@@ -157,7 +140,6 @@ test.group("Permissions", (group) => {
 
     // Regular user cannot create related
     const { token: userToken } = await createUserWithToken(
-      uniqueEmail,
       "user3",
       "Perm User 3",
     );
@@ -195,13 +177,11 @@ test.group("Permissions", (group) => {
     const milestone = await Milestone.create({ name: "PermTest Milestone" });
 
     const { token: userToken } = await createUserWithToken(
-      uniqueEmail,
       "user4",
       "Perm User 4",
     );
 
     const { token: adminToken } = await createAdminWithToken(
-      uniqueEmail,
       "admin4",
       "Solvro Admin 4",
     );
@@ -243,7 +223,6 @@ test.group("Permissions", (group) => {
     client,
   }) => {
     const { token: adminToken } = await createAdminWithToken(
-      uniqueEmail,
       "admin5",
       "Solvro Admin 5",
     );
@@ -263,7 +242,6 @@ test.group("Permissions", (group) => {
 
     // Regular user cannot delete
     const { token: userToken } = await createUserWithToken(
-      uniqueEmail,
       "user5",
       "Perm User 5",
     );

--- a/tests/functional/permissions.spec.ts
+++ b/tests/functional/permissions.spec.ts
@@ -1,10 +1,6 @@
-import jwt from "jsonwebtoken";
-import crypto from "node:crypto";
-
 import { test } from "@japa/runner";
 
 import testUtils from "@adonisjs/core/services/test_utils";
-import db from "@adonisjs/lucid/services/db";
 
 import { Branch } from "#enums/branch";
 import { Weekday } from "#enums/weekday";
@@ -13,93 +9,14 @@ import Library from "#models/library";
 import Milestone from "#models/milestone";
 import Role from "#models/role";
 import User from "#models/user";
-import env from "#start/env";
 
-function uniqueEmail(prefix: string) {
-  const id = crypto.randomUUID().slice(0, 8);
-  return `${prefix}-${id}@perm.test`;
-}
+import {
+  createAdminWithToken,
+  createUniqueEmail,
+  createUserWithToken,
+} from "./auth_helpers.js";
 
-async function makeToken(user: User): Promise<string> {
-  const ACCESS_SECRET = env.get("ACCESS_SECRET");
-  const AUDIENCE = "admin.topwr.solvro.pl";
-  const ISSUER = "admin.topwr.solvro.pl";
-  const ACCESS_EXPIRES_IN_MS = Number.parseInt(
-    env.get("ACCESS_EXPIRES_IN_MS", "3600000"),
-  );
-
-  return jwt.sign(
-    {
-      isRefresh: false,
-    },
-    ACCESS_SECRET,
-    {
-      subject: user.id.toString(),
-      audience: AUDIENCE,
-      issuer: ISSUER,
-      expiresIn: ACCESS_EXPIRES_IN_MS,
-      algorithm: "HS256",
-      allowInsecureKeySizes: false,
-      allowInvalidAsymmetricKeyTypes: false,
-    },
-  );
-}
-
-async function ensureSolvroAdminRoleId(): Promise<number> {
-  // Ensure 'solvro_admin' exists in access_roles and return its id
-  const existing: unknown = await db
-    .knexQuery()
-    .table("access_roles")
-    .where({ slug: "solvro_admin" })
-    .first();
-  if (existing !== null && existing !== undefined) {
-    return Number((existing as { id: number | string }).id);
-  }
-
-  const idNum = await db
-    .knexQuery()
-    .table("access_roles")
-    .insert({
-      slug: "solvro_admin",
-      created_at: new Date(),
-      updated_at: new Date(),
-    })
-    .returning("id")
-    .then((result: unknown) => {
-      if (Array.isArray(result)) {
-        const first = result[0] as unknown;
-        if (typeof first === "object" && first !== null && "id" in first) {
-          return Number((first as { id: number | string }).id);
-        }
-        return Number(first);
-      }
-      if (typeof result === "object" && result !== null && "id" in result) {
-        return Number((result as { id: number | string }).id);
-      }
-      return Number(result);
-    });
-
-  return idNum;
-}
-
-async function assignSolvroAdmin(user: User) {
-  const roleId = await ensureSolvroAdminRoleId();
-  // model_roles: model_type, model_id, role_id
-  const existing: unknown = await db
-    .knexQuery()
-    .table("model_roles")
-    .where({ model_type: "users", model_id: user.id, role_id: roleId })
-    .first();
-  if (existing === null || existing === undefined) {
-    await db.knexQuery().table("model_roles").insert({
-      model_type: "users",
-      model_id: user.id,
-      role_id: roleId,
-      created_at: new Date(),
-      updated_at: new Date(),
-    });
-  }
-}
+const uniqueEmail = createUniqueEmail("perm.test");
 
 test.group("Permissions", (group) => {
   group.setup(async () => {
@@ -123,12 +40,11 @@ test.group("Permissions", (group) => {
   test("store requires permission: regular user gets 403", async ({
     client,
   }) => {
-    const user = await User.create({
-      email: uniqueEmail("user1"),
-      password: "Passw0rd!",
-      fullName: "Perm User 1",
-    });
-    const token = await makeToken(user);
+    const { token } = await createUserWithToken(
+      uniqueEmail,
+      "user1",
+      "Perm User 1",
+    );
 
     const res = await client
       .post("/api/v1/libraries")
@@ -139,13 +55,11 @@ test.group("Permissions", (group) => {
   });
 
   test("solvro_admin bypass: can store", async ({ client, assert }) => {
-    const adminUser = await User.create({
-      email: uniqueEmail("admin1"),
-      password: "Passw0rd!",
-      fullName: "Solvro Admin",
-    });
-    await assignSolvroAdmin(adminUser);
-    const token = await makeToken(adminUser);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin1",
+      "Solvro Admin",
+    );
 
     const res = await client
       .post("/api/v1/libraries")
@@ -171,13 +85,12 @@ test.group("Permissions", (group) => {
     assert,
   }) => {
     // Create a record as solvro_admin
-    const adminUser = await User.create({
-      email: uniqueEmail("admin2"),
-      password: "Passw0rd!",
-      fullName: "Solvro Admin 2",
-    });
-    await assignSolvroAdmin(adminUser);
-    const adminToken = await makeToken(adminUser);
+    const { token: adminToken } = await createAdminWithToken(
+      uniqueEmail,
+      "admin2",
+      "Solvro Admin 2",
+    );
+
     const created = await client
       .post("/api/v1/libraries")
       .header("Authorization", `Bearer ${adminToken}`)
@@ -192,12 +105,12 @@ test.group("Permissions", (group) => {
     const id = Number(bodyC.data?.id);
 
     // Regular user cannot update
-    const user = await User.create({
-      email: uniqueEmail("user2"),
-      password: "Passw0rd!",
-      fullName: "Perm User 2",
-    });
-    const userToken = await makeToken(user);
+    const { token: userToken } = await createUserWithToken(
+      uniqueEmail,
+      "user2",
+      "Perm User 2",
+    );
+
     const bad = await client
       .patch(`/api/v1/libraries/${id}`)
       .header("Authorization", `Bearer ${userToken}`)
@@ -218,13 +131,11 @@ test.group("Permissions", (group) => {
     client,
     assert,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin3"),
-      password: "Passw0rd!",
-      fullName: "Solvro Admin 3",
-    });
-    await assignSolvroAdmin(admin);
-    const adminToken = await makeToken(admin);
+    const { token: adminToken } = await createAdminWithToken(
+      uniqueEmail,
+      "admin3",
+      "Solvro Admin 3",
+    );
 
     const created = await client
       .post("/api/v1/libraries")
@@ -245,12 +156,12 @@ test.group("Permissions", (group) => {
     assert.property(ri.body(), "data");
 
     // Regular user cannot create related
-    const user = await User.create({
-      email: uniqueEmail("user3"),
-      password: "Passw0rd!",
-      fullName: "Perm User 3",
-    });
-    const userToken = await makeToken(user);
+    const { token: userToken } = await createUserWithToken(
+      uniqueEmail,
+      "user3",
+      "Perm User 3",
+    );
+
     const badStore = await client
       .post(`/api/v1/libraries/${libId}/regular_hours`)
       .header("Authorization", `Bearer ${userToken}`)
@@ -283,20 +194,17 @@ test.group("Permissions", (group) => {
     const person = await Contributor.create({ name: "PermTest Contributor" });
     const milestone = await Milestone.create({ name: "PermTest Milestone" });
 
-    const user = await User.create({
-      email: uniqueEmail("user4"),
-      password: "Passw0rd!",
-      fullName: "Perm User 4",
-    });
-    const userToken = await makeToken(user);
+    const { token: userToken } = await createUserWithToken(
+      uniqueEmail,
+      "user4",
+      "Perm User 4",
+    );
 
-    const admin = await User.create({
-      email: uniqueEmail("admin4"),
-      password: "Passw0rd!",
-      fullName: "Solvro Admin 4",
-    });
-    await assignSolvroAdmin(admin);
-    const adminToken = await makeToken(admin);
+    const { token: adminToken } = await createAdminWithToken(
+      uniqueEmail,
+      "admin4",
+      "Solvro Admin 4",
+    );
 
     // Regular user cannot attach
     const badAttach = await client
@@ -329,42 +237,16 @@ test.group("Permissions", (group) => {
     okDetach.assertStatus(200);
     const okDetachBody = okDetach.body() as unknown as { success?: boolean };
     assert.equal(okDetachBody.success, true);
-
-    // Re-attach for pivot update permission checks (milestones have updatable pivot order)
-    await db.knexQuery().table("contributor_roles").insert({
-      contributor_id: person.id,
-      role_id: role.id,
-      milestone_id: milestone.id,
-      order: 1,
-      created_at: new Date(),
-      updated_at: new Date(),
-    });
-
-    const badPatch = await client
-      .patch(`/api/v1/milestones/${milestone.id}/contributors/${person.id}`)
-      .header("Authorization", `Bearer ${userToken}`)
-      .json({ query: { role_id: role.id }, update: { order: 2 } });
-    badPatch.assertStatus(403);
-
-    const okPatch = await client
-      .patch(`/api/v1/milestones/${milestone.id}/contributors/${person.id}`)
-      .header("Authorization", `Bearer ${adminToken}`)
-      .json({ query: { role_id: role.id }, update: { order: 2 } });
-    okPatch.assertStatus(200);
-    const okPatchBody = okPatch.body() as unknown as { success?: boolean };
-    assert.equal(okPatchBody.success, true);
   });
 
   test("destroy blocked without permission; allowed for solvro_admin", async ({
     client,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin5"),
-      password: "Passw0rd!",
-      fullName: "Solvro Admin 5",
-    });
-    await assignSolvroAdmin(admin);
-    const adminToken = await makeToken(admin);
+    const { token: adminToken } = await createAdminWithToken(
+      uniqueEmail,
+      "admin5",
+      "Solvro Admin 5",
+    );
 
     const created = await client
       .post("/api/v1/libraries")
@@ -380,12 +262,12 @@ test.group("Permissions", (group) => {
     const id = Number(cBody.data?.id);
 
     // Regular user cannot delete
-    const user = await User.create({
-      email: uniqueEmail("user5"),
-      password: "Passw0rd!",
-      fullName: "Perm User 5",
-    });
-    const userToken = await makeToken(user);
+    const { token: userToken } = await createUserWithToken(
+      uniqueEmail,
+      "user5",
+      "Perm User 5",
+    );
+
     const bad = await client
       .delete(`/api/v1/libraries/${id}`)
       .header("Authorization", `Bearer ${userToken}`);
@@ -396,39 +278,5 @@ test.group("Permissions", (group) => {
       .delete(`/api/v1/libraries/${id}`)
       .header("Authorization", `Bearer ${adminToken}`);
     ok.assertStatus(200);
-  });
-
-  test("user routes validate and use the :id route parameter", async ({
-    client,
-  }) => {
-    const admin = await User.create({
-      email: uniqueEmail("users-admin"),
-      password: "Passw0rd!",
-      fullName: "Users Route Admin",
-    });
-    await assignSolvroAdmin(admin);
-    const adminToken = await makeToken(admin);
-
-    const target = await User.create({
-      email: uniqueEmail("users-target"),
-      password: "Passw0rd!",
-      fullName: "Users Route Target",
-    });
-
-    const show = await client
-      .get(`/api/v1/users/${target.id}`)
-      .header("Authorization", `Bearer ${adminToken}`);
-    show.assertStatus(200);
-
-    const update = await client
-      .patch(`/api/v1/users/${target.id}`)
-      .header("Authorization", `Bearer ${adminToken}`)
-      .json({ fullName: "Users Route Updated" });
-    update.assertStatus(200);
-
-    const destroy = await client
-      .delete(`/api/v1/users/${target.id}`)
-      .header("Authorization", `Bearer ${adminToken}`);
-    destroy.assertStatus(200);
   });
 });

--- a/tests/functional/permissions_cleanup.spec.ts
+++ b/tests/functional/permissions_cleanup.spec.ts
@@ -1,5 +1,4 @@
 import { Acl } from "@holoyan/adonisjs-permissions";
-import jwt from "jsonwebtoken";
 import crypto from "node:crypto";
 
 import { test } from "@japa/runner";
@@ -13,39 +12,22 @@ import { OrganizationStatus } from "#enums/organization_status";
 import { OrganizationType } from "#enums/organization_type";
 import StudentOrganizationDraft from "#models/student_organization_draft";
 import User from "#models/user";
-import env from "#start/env";
 import {
   aclTotal,
   deleteOrphanedPermissionsForModel,
   deletePermissionsForEntity,
 } from "#utils/permissions";
 
+import {
+  createAdminWithToken,
+  createUniqueEmail,
+  createUserWithToken,
+} from "./auth_helpers.js";
+
+const uniqueEmail = createUniqueEmail("cleanup.test");
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function uniqueEmail(prefix: string) {
-  const id = crypto.randomUUID().slice(0, 8);
-  return `${prefix}-${id}@cleanup.test`;
-}
-
-async function makeToken(user: User): Promise<string> {
-  const ACCESS_SECRET = env.get("ACCESS_SECRET");
-  const AUDIENCE = "admin.topwr.solvro.pl";
-  const ISSUER = "admin.topwr.solvro.pl";
-  const ACCESS_EXPIRES_IN_MS = Number.parseInt(
-    env.get("ACCESS_EXPIRES_IN_MS", "3600000"),
-  );
-  return jwt.sign({ isRefresh: false }, ACCESS_SECRET, {
-    subject: user.id.toString(),
-    audience: AUDIENCE,
-    issuer: ISSUER,
-    expiresIn: ACCESS_EXPIRES_IN_MS,
-    algorithm: "HS256",
-    allowInsecureKeySizes: false,
-    allowInvalidAsymmetricKeyTypes: false,
-  });
-}
 
 async function countPermissionsFor(
   entityType: string,
@@ -139,50 +121,6 @@ async function insertModelRoleRow(
     created_at: new Date(),
     updated_at: new Date(),
   });
-}
-
-async function ensureSolvroAdminRoleId(): Promise<number> {
-  const existing = (await db
-    .knexQuery()
-    .table("access_roles")
-    .where({ slug: "solvro_admin" })
-    .first()) as { id: number | string } | undefined | null;
-  if (existing !== null && existing !== undefined) {
-    return Number(existing.id);
-  }
-  const result = await db
-    .knexQuery()
-    .table("access_roles")
-    .insert({
-      slug: "solvro_admin",
-      created_at: new Date(),
-      updated_at: new Date(),
-    })
-    .returning("id");
-  const first = (result as unknown[])[0];
-  if (typeof first === "object" && first !== null && "id" in first) {
-    return Number((first as { id: number | string }).id);
-  }
-  return Number(first);
-}
-
-async function assignSolvroAdmin(user: User): Promise<void> {
-  const roleId = await ensureSolvroAdminRoleId();
-  const exists = await db
-    .knexQuery()
-    .table("model_roles")
-    .where({ model_type: "users", model_id: user.id, role_id: roleId })
-    .first()
-    .then((row: unknown) => row !== null && row !== undefined);
-  if (!exists) {
-    await db.knexQuery().table("model_roles").insert({
-      model_type: "users",
-      model_id: user.id,
-      role_id: roleId,
-      created_at: new Date(),
-      updated_at: new Date(),
-    });
-  }
 }
 
 async function createBaseDraft(
@@ -499,13 +437,13 @@ test.group("BaseController.destroy() auto-cleanup", (group) => {
     client,
     assert,
   }) => {
-    const user = await User.create({
-      email: uniqueEmail("destroycleanup1"),
-      password: "Passw0rd!",
-      fullName: "Destroy Cleanup User",
-    });
+    const { user, token } = await createUserWithToken(
+      uniqueEmail,
+      "destroycleanup",
+      "Destroy Cleanup User",
+    );
+
     await user.refresh();
-    const token = await makeToken(user);
 
     const draft = await createBaseDraft(user.id);
 
@@ -549,13 +487,13 @@ test.group("BaseController.destroy() auto-cleanup", (group) => {
     client,
     assert,
   }) => {
-    const user = await User.create({
-      email: uniqueEmail("destroycleanup2"),
-      password: "Passw0rd!",
-      fullName: "Destroy Cleanup User 2",
-    });
+    const { user, token } = await createUserWithToken(
+      uniqueEmail,
+      "destroycleanup2",
+      "Destroy Cleanup User 2",
+    );
+
     await user.refresh();
-    const token = await makeToken(user);
 
     const draftToDelete = await createBaseDraft(user.id);
     const draftToKeep = await createBaseDraft(user.id);
@@ -603,13 +541,13 @@ test.group("BaseController.destroy() auto-cleanup", (group) => {
     });
 
     // Need solvro_admin to delete a Library
-    const admin = await User.create({
-      email: uniqueEmail("libadmin"),
-      password: "Passw0rd!",
-      fullName: "Lib Admin",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { user: admin, token } = await createAdminWithToken(
+      uniqueEmail,
+      "libadmin",
+      "Lib Admin",
+    );
+
+    await admin.refresh();
 
     const res = await client
       .delete(`/api/v1/libraries/${lib.id}`)

--- a/tests/functional/permissions_cleanup.spec.ts
+++ b/tests/functional/permissions_cleanup.spec.ts
@@ -20,11 +20,10 @@ import {
 
 import {
   createAdminWithToken,
-  createUniqueEmail,
   createUserWithToken,
+  uniqueEmail,
 } from "./auth_helpers.js";
 
-const uniqueEmail = createUniqueEmail("cleanup.test");
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -438,12 +437,9 @@ test.group("BaseController.destroy() auto-cleanup", (group) => {
     assert,
   }) => {
     const { user, token } = await createUserWithToken(
-      uniqueEmail,
       "destroycleanup",
       "Destroy Cleanup User",
     );
-
-    await user.refresh();
 
     const draft = await createBaseDraft(user.id);
 
@@ -488,12 +484,9 @@ test.group("BaseController.destroy() auto-cleanup", (group) => {
     assert,
   }) => {
     const { user, token } = await createUserWithToken(
-      uniqueEmail,
       "destroycleanup2",
       "Destroy Cleanup User 2",
     );
-
-    await user.refresh();
 
     const draftToDelete = await createBaseDraft(user.id);
     const draftToKeep = await createBaseDraft(user.id);
@@ -541,13 +534,7 @@ test.group("BaseController.destroy() auto-cleanup", (group) => {
     });
 
     // Need solvro_admin to delete a Library
-    const { user: admin, token } = await createAdminWithToken(
-      uniqueEmail,
-      "libadmin",
-      "Lib Admin",
-    );
-
-    await admin.refresh();
+    const { token } = await createAdminWithToken("libadmin", "Lib Admin");
 
     const res = await client
       .delete(`/api/v1/libraries/${lib.id}`)

--- a/tests/functional/users_management.spec.ts
+++ b/tests/functional/users_management.spec.ts
@@ -6,11 +6,9 @@ import User from "#models/user";
 
 import {
   createAdminWithToken,
-  createUniqueEmail,
   createUserWithToken,
+  uniqueEmail,
 } from "./auth_helpers.js";
-
-const uniqueEmail = createUniqueEmail("user.test");
 
 test.group("User Management API", (group) => {
   group.setup(async () => {
@@ -24,11 +22,7 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin1",
-      "Solvro Admin",
-    );
+    const { token } = await createAdminWithToken("admin1", "Solvro Admin");
 
     const response = await client.get("/api/v1/users").bearerToken(token);
 
@@ -54,11 +48,7 @@ test.group("User Management API", (group) => {
   test("get /api/v1/users requires superuser: regular user gets 403 ", async ({
     client,
   }) => {
-    const { token } = await createUserWithToken(
-      uniqueEmail,
-      "user1",
-      "Regular User 1",
-    );
+    const { token } = await createUserWithToken("user1", "Regular User 1");
 
     const response = await client.get("/api/v1/users").bearerToken(token);
 
@@ -69,11 +59,7 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin2",
-      "Solvro Admin 2",
-    );
+    const { token } = await createAdminWithToken("admin2", "Solvro Admin 2");
 
     const targetUser = await User.create({
       email: uniqueEmail("target"),
@@ -96,11 +82,7 @@ test.group("User Management API", (group) => {
   test("get /api/v1/users/:id requires superuser: regular user gets 403", async ({
     client,
   }) => {
-    const { token } = await createUserWithToken(
-      uniqueEmail,
-      "user2",
-      "Regular User 2",
-    );
+    const { token } = await createUserWithToken("user2", "Regular User 2");
 
     const targetUser = await User.create({
       email: uniqueEmail("target_user"),
@@ -132,11 +114,7 @@ test.group("User Management API", (group) => {
   test("get /api/v1/users/:id returns 404 when user does not exist", async ({
     client,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin3",
-      "Solvro Admin 3",
-    );
+    const { token } = await createAdminWithToken("admin3", "Solvro Admin 3");
     const fakeId = 999999;
 
     const response = await client
@@ -158,11 +136,7 @@ test.group("User Management API", (group) => {
   test("get /api/v1/users/:id prevents data leak: regular user gets 403 for nonexistent user", async ({
     client,
   }) => {
-    const { token } = await createUserWithToken(
-      uniqueEmail,
-      "user3",
-      "Regular User 3",
-    );
+    const { token } = await createUserWithToken("user3", "Regular User 3");
     const fakeId = 999999;
 
     const response = await client
@@ -176,11 +150,7 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin4",
-      "Solvro Admin 4",
-    );
+    const { token } = await createAdminWithToken("admin4", "Solvro Admin 4");
 
     const newUserEmail = uniqueEmail("new.user");
     const newUserData = {
@@ -209,11 +179,7 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin5",
-      "Solvro Admin 5",
-    );
+    const { token } = await createAdminWithToken("admin5", "Solvro Admin 5");
 
     const newUserBadData = {
       email: uniqueEmail("bad_pass"),
@@ -234,11 +200,7 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin6",
-      "Solvro Admin 6",
-    );
+    const { token } = await createAdminWithToken("admin6", "Solvro Admin 6");
 
     const takenEmail = uniqueEmail("taken");
     await User.create({
@@ -265,11 +227,7 @@ test.group("User Management API", (group) => {
   test("post /api/v1/users requires superuser: regular user gets 403", async ({
     client,
   }) => {
-    const { token } = await createUserWithToken(
-      uniqueEmail,
-      "user4",
-      "Regular User 4",
-    );
+    const { token } = await createUserWithToken("user4", "Regular User 4");
 
     const newUser = {
       email: uniqueEmail("new_user"),
@@ -302,11 +260,7 @@ test.group("User Management API", (group) => {
   test("delete /api/v1/users/:id deletes user when requested by admin", async ({
     client,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin7",
-      "Solvro Admin 7",
-    );
+    const { token } = await createAdminWithToken("admin7", "Solvro Admin 7");
 
     const userToDelete = await User.create({
       email: uniqueEmail("to_delete"),
@@ -326,11 +280,7 @@ test.group("User Management API", (group) => {
   test("delete /api/v1/users/:id requires superuser: regular user gets 403", async ({
     client,
   }) => {
-    const { token } = await createUserWithToken(
-      uniqueEmail,
-      "user5",
-      "Regular User 5",
-    );
+    const { token } = await createUserWithToken("user5", "Regular User 5");
 
     const targetUser = await User.create({
       email: uniqueEmail("targe_user"),
@@ -362,11 +312,7 @@ test.group("User Management API", (group) => {
   test("delete /api/v1/users/:id returns 404 when user does not exist", async ({
     client,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin8",
-      "Solvro Admin 8",
-    );
+    const { token } = await createAdminWithToken("admin8", "Solvro Admin 8");
 
     const fakeUserId = 999999;
 
@@ -389,11 +335,7 @@ test.group("User Management API", (group) => {
   test("delete /api/v1/users/:id prevents data leak: regular user gets 403 for nonexistent user", async ({
     client,
   }) => {
-    const { token } = await createUserWithToken(
-      uniqueEmail,
-      "user6",
-      "Regular User 6",
-    );
+    const { token } = await createUserWithToken("user6", "Regular User 6");
     const fakeId = 999999;
 
     const response = await client
@@ -407,11 +349,7 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin9",
-      "Solvro Admin 9",
-    );
+    const { token } = await createAdminWithToken("admin9", "Solvro Admin 9");
 
     const originalEmail = uniqueEmail("to_change");
     const targetUser = await User.create({
@@ -447,11 +385,7 @@ test.group("User Management API", (group) => {
   test("patch /api/v1/users/:id requires superuser: regular user gets 403", async ({
     client,
   }) => {
-    const { token } = await createUserWithToken(
-      uniqueEmail,
-      "user7",
-      "Regular User 7",
-    );
+    const { token } = await createUserWithToken("user7", "Regular User 7");
 
     const targetUser = await User.create({
       email: uniqueEmail("target_user"),
@@ -488,11 +422,7 @@ test.group("User Management API", (group) => {
   test("patch /api/v1/users/:id returns 404 when user does not exist", async ({
     client,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin10",
-      "Solvro Admin 10",
-    );
+    const { token } = await createAdminWithToken("admin10", "Solvro Admin 10");
 
     const fakeUserId = 999999;
 
@@ -520,11 +450,7 @@ test.group("User Management API", (group) => {
   test("patch /api/v1/users/:id prevents data leak: regular user gets 403 for nonexistent user", async ({
     client,
   }) => {
-    const { token } = await createUserWithToken(
-      uniqueEmail,
-      "user8",
-      "Regular User 8",
-    );
+    const { token } = await createUserWithToken("user8", "Regular User 8");
     const fakeId = 999999;
 
     const response = await client
@@ -541,11 +467,7 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin11",
-      "Solvro Admin 11",
-    );
+    const { token } = await createAdminWithToken("admin11", "Solvro Admin 11");
 
     const targetUser = await User.create({
       email: uniqueEmail("target_user"),
@@ -575,11 +497,7 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const { token } = await createAdminWithToken(
-      uniqueEmail,
-      "admin12",
-      "Solvro Admin 12",
-    );
+    const { token } = await createAdminWithToken("admin12", "Solvro Admin 12");
 
     const targetUser = await User.create({
       email: uniqueEmail("target_user"),

--- a/tests/functional/users_management.spec.ts
+++ b/tests/functional/users_management.spec.ts
@@ -1,99 +1,16 @@
-import jwt from "jsonwebtoken";
-import crypto from "node:crypto";
-
 import { test } from "@japa/runner";
 
 import testUtils from "@adonisjs/core/services/test_utils";
-import db from "@adonisjs/lucid/services/db";
 
 import User from "#models/user";
-import env from "#start/env";
 
-function uniqueEmail(prefix: string) {
-  const id = crypto.randomUUID().slice(0, 8);
-  return `${prefix}-${id}@user.test`;
-}
+import {
+  createAdminWithToken,
+  createUniqueEmail,
+  createUserWithToken,
+} from "./auth_helpers.js";
 
-async function makeToken(user: User): Promise<string> {
-  const ACCESS_SECRET = env.get("ACCESS_SECRET");
-  const AUDIENCE = "admin.topwr.solvro.pl";
-  const ISSUER = "admin.topwr.solvro.pl";
-  const ACCESS_EXPIRES_IN_MS = Number.parseInt(
-    env.get("ACCESS_EXPIRES_IN_MS", "3600000"),
-  );
-
-  return jwt.sign(
-    {
-      isRefresh: false,
-    },
-    ACCESS_SECRET,
-    {
-      subject: user.id.toString(),
-      audience: AUDIENCE,
-      issuer: ISSUER,
-      expiresIn: ACCESS_EXPIRES_IN_MS,
-      algorithm: "HS256",
-      allowInsecureKeySizes: false,
-      allowInvalidAsymmetricKeyTypes: false,
-    },
-  );
-}
-
-async function ensureSolvroAdminRoleId(): Promise<number> {
-  // Ensure 'solvro_admin' exists in access_roles and return its id
-  const existing: unknown = await db
-    .knexQuery()
-    .table("access_roles")
-    .where({ slug: "solvro_admin" })
-    .first();
-  if (existing !== null && existing !== undefined) {
-    return Number((existing as { id: number | string }).id);
-  }
-
-  const idNum = await db
-    .knexQuery()
-    .table("access_roles")
-    .insert({
-      slug: "solvro_admin",
-      created_at: new Date(),
-      updated_at: new Date(),
-    })
-    .returning("id")
-    .then((result: unknown) => {
-      if (Array.isArray(result)) {
-        const first = result[0] as unknown;
-        if (typeof first === "object" && first !== null && "id" in first) {
-          return Number((first as { id: number | string }).id);
-        }
-        return Number(first);
-      }
-      if (typeof result === "object" && result !== null && "id" in result) {
-        return Number((result as { id: number | string }).id);
-      }
-      return Number(result);
-    });
-
-  return idNum;
-}
-
-async function assignSolvroAdmin(user: User) {
-  const roleId = await ensureSolvroAdminRoleId();
-  // model_roles: model_type, model_id, role_id
-  const existing: unknown = await db
-    .knexQuery()
-    .table("model_roles")
-    .where({ model_type: "users", model_id: user.id, role_id: roleId })
-    .first();
-  if (existing === null || existing === undefined) {
-    await db.knexQuery().table("model_roles").insert({
-      model_type: "users",
-      model_id: user.id,
-      role_id: roleId,
-      created_at: new Date(),
-      updated_at: new Date(),
-    });
-  }
-}
+const uniqueEmail = createUniqueEmail("user.test");
 
 test.group("User Management API", (group) => {
   group.setup(async () => {
@@ -107,13 +24,11 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const adminUser = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 1",
-    });
-    await assignSolvroAdmin(adminUser);
-    const token = await makeToken(adminUser);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin1",
+      "Solvro Admin",
+    );
 
     const response = await client.get("/api/v1/users").bearerToken(token);
 
@@ -139,12 +54,11 @@ test.group("User Management API", (group) => {
   test("get /api/v1/users requires superuser: regular user gets 403 ", async ({
     client,
   }) => {
-    const regularUser = await User.create({
-      email: uniqueEmail("student"),
-      password: "SecurePassword123!",
-      fullName: "Regular Student 1",
-    });
-    const token = await makeToken(regularUser);
+    const { token } = await createUserWithToken(
+      uniqueEmail,
+      "user1",
+      "Regular User 1",
+    );
 
     const response = await client.get("/api/v1/users").bearerToken(token);
 
@@ -155,13 +69,11 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 2",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin2",
+      "Solvro Admin 2",
+    );
 
     const targetUser = await User.create({
       email: uniqueEmail("target"),
@@ -184,12 +96,12 @@ test.group("User Management API", (group) => {
   test("get /api/v1/users/:id requires superuser: regular user gets 403", async ({
     client,
   }) => {
-    const student = await User.create({
-      email: uniqueEmail("student"),
-      password: "SecurePassword123!",
-      fullName: "Regular User 2",
-    });
-    const token = await makeToken(student);
+    const { token } = await createUserWithToken(
+      uniqueEmail,
+      "user2",
+      "Regular User 2",
+    );
+
     const targetUser = await User.create({
       email: uniqueEmail("target_user"),
       password: "SecurePassword!987",
@@ -220,13 +132,11 @@ test.group("User Management API", (group) => {
   test("get /api/v1/users/:id returns 404 when user does not exist", async ({
     client,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 3",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin3",
+      "Solvro Admin 3",
+    );
     const fakeId = 999999;
 
     const response = await client
@@ -248,12 +158,11 @@ test.group("User Management API", (group) => {
   test("get /api/v1/users/:id prevents data leak: regular user gets 403 for nonexistent user", async ({
     client,
   }) => {
-    const regularUser = await User.create({
-      email: uniqueEmail("student"),
-      password: "SecurePassword123!",
-      fullName: "Regular User",
-    });
-    const token = await makeToken(regularUser);
+    const { token } = await createUserWithToken(
+      uniqueEmail,
+      "user3",
+      "Regular User 3",
+    );
     const fakeId = 999999;
 
     const response = await client
@@ -267,13 +176,11 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const adminUser = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 4",
-    });
-    await assignSolvroAdmin(adminUser);
-    const token = await makeToken(adminUser);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin4",
+      "Solvro Admin 4",
+    );
 
     const newUserEmail = uniqueEmail("new.user");
     const newUserData = {
@@ -302,14 +209,11 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 5",
-    });
-
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin5",
+      "Solvro Admin 5",
+    );
 
     const newUserBadData = {
       email: uniqueEmail("bad_pass"),
@@ -330,13 +234,11 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 6",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin6",
+      "Solvro Admin 6",
+    );
 
     const takenEmail = uniqueEmail("taken");
     await User.create({
@@ -363,12 +265,11 @@ test.group("User Management API", (group) => {
   test("post /api/v1/users requires superuser: regular user gets 403", async ({
     client,
   }) => {
-    const regularUser = await User.create({
-      email: uniqueEmail("student"),
-      password: "SecurePassword123!",
-      fullName: "Regular User",
-    });
-    const token = await makeToken(regularUser);
+    const { token } = await createUserWithToken(
+      uniqueEmail,
+      "user4",
+      "Regular User 4",
+    );
 
     const newUser = {
       email: uniqueEmail("new_user"),
@@ -401,13 +302,11 @@ test.group("User Management API", (group) => {
   test("delete /api/v1/users/:id deletes user when requested by admin", async ({
     client,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 7",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin7",
+      "Solvro Admin 7",
+    );
 
     const userToDelete = await User.create({
       email: uniqueEmail("to_delete"),
@@ -427,12 +326,11 @@ test.group("User Management API", (group) => {
   test("delete /api/v1/users/:id requires superuser: regular user gets 403", async ({
     client,
   }) => {
-    const regularUser = await User.create({
-      email: uniqueEmail("student"),
-      password: "SecurePassword123!",
-      fullName: "Regular User",
-    });
-    const token = await makeToken(regularUser);
+    const { token } = await createUserWithToken(
+      uniqueEmail,
+      "user5",
+      "Regular User 5",
+    );
 
     const targetUser = await User.create({
       email: uniqueEmail("targe_user"),
@@ -464,13 +362,11 @@ test.group("User Management API", (group) => {
   test("delete /api/v1/users/:id returns 404 when user does not exist", async ({
     client,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 8",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin8",
+      "Solvro Admin 8",
+    );
 
     const fakeUserId = 999999;
 
@@ -493,12 +389,11 @@ test.group("User Management API", (group) => {
   test("delete /api/v1/users/:id prevents data leak: regular user gets 403 for nonexistent user", async ({
     client,
   }) => {
-    const regularUser = await User.create({
-      email: uniqueEmail("student"),
-      password: "SecurePassword123!",
-      fullName: "Regular User",
-    });
-    const token = await makeToken(regularUser);
+    const { token } = await createUserWithToken(
+      uniqueEmail,
+      "user6",
+      "Regular User 6",
+    );
     const fakeId = 999999;
 
     const response = await client
@@ -512,13 +407,11 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 9",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin9",
+      "Solvro Admin 9",
+    );
 
     const originalEmail = uniqueEmail("to_change");
     const targetUser = await User.create({
@@ -554,12 +447,11 @@ test.group("User Management API", (group) => {
   test("patch /api/v1/users/:id requires superuser: regular user gets 403", async ({
     client,
   }) => {
-    const regularUser = await User.create({
-      email: uniqueEmail("regular_user"),
-      password: "SecurePassword123!",
-      fullName: "Regular User",
-    });
-    const token = await makeToken(regularUser);
+    const { token } = await createUserWithToken(
+      uniqueEmail,
+      "user7",
+      "Regular User 7",
+    );
 
     const targetUser = await User.create({
       email: uniqueEmail("target_user"),
@@ -596,13 +488,11 @@ test.group("User Management API", (group) => {
   test("patch /api/v1/users/:id returns 404 when user does not exist", async ({
     client,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 9",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin10",
+      "Solvro Admin 10",
+    );
 
     const fakeUserId = 999999;
 
@@ -630,12 +520,11 @@ test.group("User Management API", (group) => {
   test("patch /api/v1/users/:id prevents data leak: regular user gets 403 for nonexistent user", async ({
     client,
   }) => {
-    const regularUser = await User.create({
-      email: uniqueEmail("student"),
-      password: "SecurePassword123!",
-      fullName: "Regular User",
-    });
-    const token = await makeToken(regularUser);
+    const { token } = await createUserWithToken(
+      uniqueEmail,
+      "user8",
+      "Regular User 8",
+    );
     const fakeId = 999999;
 
     const response = await client
@@ -652,13 +541,11 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 10",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin11",
+      "Solvro Admin 11",
+    );
 
     const targetUser = await User.create({
       email: uniqueEmail("target_user"),
@@ -688,13 +575,11 @@ test.group("User Management API", (group) => {
     client,
     assert,
   }) => {
-    const admin = await User.create({
-      email: uniqueEmail("admin"),
-      password: "SecurePassword123!",
-      fullName: "Admin 11",
-    });
-    await assignSolvroAdmin(admin);
-    const token = await makeToken(admin);
+    const { token } = await createAdminWithToken(
+      uniqueEmail,
+      "admin12",
+      "Solvro Admin 12",
+    );
 
     const targetUser = await User.create({
       email: uniqueEmail("target_user"),


### PR DESCRIPTION
Extracted repeated helper functions (uniqueEmail, makeToken, ensureSolvroAdminRoleId, assignSolvroAdmin) from drafts_acl.spec.ts, permissions.spec.ts, permissions_cleanup.spec.ts, and users_management.spec.ts into a shared auth_helpers.ts module, imported wherever needed.
Also added createUserWithToken / createAdminWithToken helpers to reduce repeated "create user + get token" boilerplate across the same test files.
CLOSES: #323 