### PR TITLE
fix(lint): mark unreassigned members as readonly (S2933)

### DIFF
--- a/app/auth/guards/jwt.ts
+++ b/app/auth/guards/jwt.ts
@@ -66,7 +66,7 @@ interface RefreshTokenPayload extends SupportedPayload {
 }
 
 export class JwtGuard implements GuardContract<User> {
-  #ctx: HttpContext;
+  readonly #ctx: HttpContext;
 
   constructor(ctx: HttpContext) {
     this.#ctx = ctx;

--- a/app/services/newsfeed_service.ts
+++ b/app/services/newsfeed_service.ts
@@ -58,10 +58,10 @@ export default class NewsfeedService {
     {};
   private static interval?: NodeJS.Timeout;
 
-  private static parseNewsfeedItem = (
+  private static parseNewsfeedItem(
     newsfeedItem: HTMLElement,
     baseUrl: string,
-  ): NewsfeedArticle => {
+  ): NewsfeedArticle {
     const imageLink = newsfeedItem
       .querySelector(".photo")
       ?.querySelector("img")
@@ -86,7 +86,7 @@ export default class NewsfeedService {
       categories,
       previewText: newsfeedItem.querySelector("p.desc")?.textContent.trim(),
     };
-  };
+  }
 
   private static extractNewsfeedItems(
     html: string,

--- a/app/utils/model_autogen.ts
+++ b/app/utils/model_autogen.ts
@@ -47,11 +47,11 @@ export class AutogenCacheEntry {
   #storeValidator?: AnyValidator;
   #updateValidator?: AnyValidator;
   // indexed by relation name
-  #relationStoreValidators = new Map<string, AnyValidator>();
-  #relationAttachValidators = new Map<string, AnyValidator>();
-  #relationDetachValidators = new Map<string, AnyValidator>();
-  #relationUpdatePivotValidators = new Map<string, AnyValidator>();
-  #manyToManyIdValidators = new Map<string, AnyValidator>();
+  readonly #relationStoreValidators = new Map<string, AnyValidator>();
+  readonly #relationAttachValidators = new Map<string, AnyValidator>();
+  readonly #relationDetachValidators = new Map<string, AnyValidator>();
+  readonly #relationUpdatePivotValidators = new Map<string, AnyValidator>();
+  readonly #manyToManyIdValidators = new Map<string, AnyValidator>();
 
   private constructor(model: LucidModel) {
     this.model = model;

--- a/commands/db_normalize_order.ts
+++ b/commands/db_normalize_order.ts
@@ -7,7 +7,7 @@ export default class DbNormalizeOrder extends BaseCommand {
   static commandName = "db:normalize-order";
   static description =
     "Replaces the order columns with a fresh integer sequence, keeping the entry order unchanged";
-  private orderedTables = ["guide_articles", "guide_questions"];
+  private readonly orderedTables = ["guide_articles", "guide_questions"];
 
   static options: CommandOptions = {
     startApp: true,

--- a/database/migrations/1770384712155_create_hidden_events_table.ts
+++ b/database/migrations/1770384712155_create_hidden_events_table.ts
@@ -3,7 +3,7 @@ import { BaseSchema } from "@adonisjs/lucid/schema";
 export default class extends BaseSchema {
   protected tableName = "hidden_events";
 
-  private googleCalIdColumnName = "google_cal_id";
+  private readonly googleCalIdColumnName = "google_cal_id";
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {

--- a/database/scrapers/event_calendar.ts
+++ b/database/scrapers/event_calendar.ts
@@ -27,13 +27,13 @@ interface GoogleCalendarEventDto {
 }
 
 class CalendarParser {
-  private events: ICSObject[];
+  private readonly events: ICSObject[];
 
   constructor(
-    private calendarString: string,
+    private readonly calendarString: string,
     // In case no logging is needed
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    private logger: (message: string) => void = (_) => {},
+    private readonly logger: (message: string) => void = (_) => {},
   ) {
     if (
       !this.calendarString.startsWith("BEGIN:VCALENDAR") ||


### PR DESCRIPTION
Fixes typescript:S2933 lints across 6 files: marks unreassigned members as readonly, converts parseNewsfeedItem from an arrow function to a standard method.
CLOSES: #329 